### PR TITLE
Fix parsing error on BadRequest.HaveError 

### DIFF
--- a/src/FluentAssertions.Web/BadRequestAssertions.cs
+++ b/src/FluentAssertions.Web/BadRequestAssertions.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Web
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedErrorField, nameof(expectedErrorField), "Cannot verify having an error against a <null> or empty field name.");
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedWildcardErrorMessage, nameof(expectedWildcardErrorMessage), "Cannot verify having an error against a <null> or empty wildcard error message.");
 
-            Func<Task<JObject>> jsonFunc = () => Subject.GetJsonObject();
+            Func<Task<JToken>> jsonFunc = () => Subject.GetJsonObject();
             var json = jsonFunc.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
 
             Execute.Assertion
@@ -110,7 +110,7 @@ namespace FluentAssertions.Web
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedErrorField, nameof(expectedErrorField), "Cannot verify having only an error against a <null> or empty field name.");
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedWildcardErrorMessage, nameof(expectedWildcardErrorMessage), "Cannot verify having only an error against a <null> or empty wildcard error message.");
 
-            Func<Task<JObject>> jsonFunc = () => Subject.GetJsonObject();
+            Func<Task<JToken>> jsonFunc = () => Subject.GetJsonObject();
             var json = jsonFunc.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
 
             Execute.Assertion
@@ -176,7 +176,7 @@ namespace FluentAssertions.Web
         {
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedErrorField, nameof(expectedErrorField), "Cannot verify not having an error against a <null> or empty field name.");
 
-            Func<Task<JObject>> jsonFunc = () => Subject.GetJsonObject();
+            Func<Task<JToken>> jsonFunc = () => Subject.GetJsonObject();
             var json = jsonFunc.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
 
             Execute.Assertion
@@ -207,7 +207,7 @@ namespace FluentAssertions.Web
         {
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedWildcardErrorMessage, nameof(expectedWildcardErrorMessage), "Cannot verify having an error against a <null> or empty wildcard error message.");
 
-            Func<Task<JObject>> jsonFunc = () => Subject.GetJsonObject();
+            Func<Task<JToken>> jsonFunc = () => Subject.GetJsonObject();
             var json = jsonFunc.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
 
             var allErrorsFields = json.GetChildrenKeys("errors");

--- a/src/FluentAssertions.Web/Internal/HttpResponseMessageExtensions.cs
+++ b/src/FluentAssertions.Web/Internal/HttpResponseMessageExtensions.cs
@@ -35,11 +35,11 @@ namespace FluentAssertions.Web.Internal
         public static async Task<string?> GetStringContent(this HttpResponseMessage response)
             => response.Content != null ? await response.Content.ReadAsStringAsync() : null;
 
-        public static async Task<JObject> GetJsonObject(this HttpResponseMessage response)
+        public static async Task<JToken> GetJsonObject(this HttpResponseMessage response)
         {
             var content = await response.GetStringContent();
 
-            return JObject.Parse(content);
+            return JToken.Parse(content, new JsonLoadSettings());
         }
     }
 }

--- a/src/FluentAssertions.Web/Internal/JsonExtensions.cs
+++ b/src/FluentAssertions.Web/Internal/JsonExtensions.cs
@@ -7,10 +7,10 @@ namespace FluentAssertions.Web.Internal
 {
     internal static class JsonExtensions
     {
-        public static bool HasKey(this JObject json, string key)
+        public static bool HasKey(this JToken json, string key)
             => json.GetByKey(key).Any();
 
-        public static IEnumerable<string> GetStringValuesByKey(this JObject json, string key)
+        public static IEnumerable<string> GetStringValuesByKey(this JToken json, string key)
         {
             var byKey = json.GetByKey(key);
             if (byKey != null && !byKey.Any())
@@ -27,7 +27,7 @@ namespace FluentAssertions.Web.Internal
             };
         }
 
-        public static IEnumerable<string> GetChildrenKeys(this JObject json, string? parentElement)
+        public static IEnumerable<string> GetChildrenKeys(this JToken json, string? parentElement)
         {
             if (string.IsNullOrEmpty(parentElement))
             {
@@ -42,18 +42,18 @@ namespace FluentAssertions.Web.Internal
                 .SelectMany(c => c.Properties().Select(p => p.Name));
         }
 
-        public static string? GetParentKey(this JObject json, string childElement) =>
+        public static string? GetParentKey(this JToken json, string childElement) =>
             (json.GetByKey(childElement)
                 .FirstOrDefault()
                 ?.Parent // JObject
                 .Parent as JProperty)
             ?.Name;
 
-        public static IEnumerable<JToken> GetByKey(this JObject json, string key) =>
+        public static IEnumerable<JToken> GetByKey(this JToken json, string key) =>
             json.AllTokens().Where(c => c.Type == JTokenType.Property
                                         && string.Equals(((JProperty)c).Name, key, StringComparison.OrdinalIgnoreCase));
 
-        private static IEnumerable<JToken> AllTokens(this JObject obj)
+        private static IEnumerable<JToken> AllTokens(this JToken obj)
         {
             var toSearch = new Stack<JToken>(obj.Children());
             while (toSearch.Count > 0)

--- a/test/FluentAssertions.Web.Tests/BadRequestAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/BadRequestAssertionsSpecs.cs
@@ -125,7 +125,7 @@ namespace FluentAssertions.Web.Tests
         }
 
         [Fact]
-        public void When_asserting_bad_request_response_with_a_the_errors_messages_as_a_single_field_to_be_BadRequest_and_have_error_field_and_error_message_it_should_succeed()
+        public void When_asserting_bad_request_response_with_the_errors_messages_as_a_single_field_to_be_BadRequest_and_have_error_field_and_error_message_it_should_succeed()
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
@@ -141,6 +141,30 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void
+            When_asserting_bad_request_response_with_a_response_content_having_an_array_to_BeBadRequest_and_have_error_field_and_error_message_it_should_throw_with_descriptive_message()
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(@"  [
+                        {
+                            ""code"": ""previous_steps_validation_error"",
+                            ""description"": null
+                        }
+                    ]", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveError("error", "*required*");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*error*");
         }
 
         [Theory]


### PR DESCRIPTION
Fix the unexpected failure when the response is an array json, as the BadRequest.HaveError is failing to parse an array