### PR TITLE
Use oldest Newtonsoft.Json that implements netstandard 1.0

### DIFF
--- a/src/FluentAssertions.Web/FluentAssertions.Web.csproj
+++ b/src/FluentAssertions.Web/FluentAssertions.Web.csproj
@@ -22,7 +22,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 </Project>
   


### PR DESCRIPTION
Installing FluentAssertions.Web in projects that use older versions of Newtonsoft.Json and AutoGenerateBindingRedirects causes some unexpected assembly binding failures.
There's no need to force users (me) to update Newtonsoft.Json :)