### PR TITLE
Bump FluentAssertions from 6.0.1 to 6.1.0

### DIFF
--- a/src/FluentAssertions.Web/FluentAssertions.Web.csproj
+++ b/src/FluentAssertions.Web/FluentAssertions.Web.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.0.1" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/test/FluentAssertions.Web.IntegrationTests/FluentAssertions.Web.IntegrationTests.csproj
+++ b/test/FluentAssertions.Web.IntegrationTests/FluentAssertions.Web.IntegrationTests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="FluentAssertions" Version="6.0.1" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/test/FluentAssertions.Web.Tests/FluentAssertions.Web.Tests.csproj
+++ b/test/FluentAssertions.Web.Tests/FluentAssertions.Web.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="FluentAssertions" Version="6.0.1" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
In fact, there is no such FA 6.0.1, so this is more like a fix
The problematic package has been unlisted (https://www.nuget.org/packages/FluentAssertions.Web/1.1.3)