### PR TITLE
HaveError: fix error with reserved properties names

### DIFF
--- a/src/FluentAssertions.Web/Internal/JsonExtensions.cs
+++ b/src/FluentAssertions.Web/Internal/JsonExtensions.cs
@@ -7,38 +7,28 @@ namespace FluentAssertions.Web.Internal
 {
     internal static class JsonExtensions
     {
-        public static bool HasKey(this JsonDocument json, string key)
-            => json.GetByKey(key).Any();
-
-        public static IEnumerable<string> GetStringValuesByKey(this JsonDocument json, string key)
+        public static IEnumerable<string> GetStringValuesOf(this JsonDocument json, string propertyName)
         {
-            var byKey = json.GetByKey(key);
+            var byKey = json.GetPropertiesByName(propertyName);
 
-            if (!byKey.Any())
-            {
-                return Enumerable.Empty<string>();
-            }
-
-            var first = byKey.First();
-            switch (first.Value.ValueKind)
-            {
-                case JsonValueKind.String:
-                    return new[] {first.Value.GetString() ?? ""};
-                case JsonValueKind.Array:
-                    return first.Value.EnumerateArray().Where(c => c.ValueKind == JsonValueKind.String).Select(c => c.GetString() ?? "");
-                default:
-                    return Enumerable.Empty<string>();
-            }
+            return GetStringValues(byKey);
         }
 
-        public static IEnumerable<string> GetChildrenKeys(this JsonDocument json, string? parentElement)
+        public static IEnumerable<string> GetStringValuesOf(this JsonProperty property, string propertyName)
+        {
+            var byKey = property.GetPropertiesByName(propertyName);
+
+            return GetStringValues(byKey);
+        }
+
+        public static IEnumerable<string> GetChildrenNames(this JsonDocument json, string? parentElement)
         {
             if (string.IsNullOrEmpty(parentElement))
             {
                 return json.RootElement.AllProperties().Select(c => c.Name);
             }
 
-            return json.GetByKey(parentElement!)
+            return json.GetPropertiesByName(parentElement!)
                 .SelectMany(c => c.Value.AllProperties().Select(p => p.Name));
         }
 
@@ -46,14 +36,37 @@ namespace FluentAssertions.Web.Internal
             => GetByKeyWithParent(json, childElement)
                 .Select(c => c.parent?.Name).FirstOrDefault();
 
-        public static IEnumerable<JsonProperty> GetByKey(this JsonDocument json, string key)
-            => json.RootElement.AllProperties().Where(property => string.Equals(property.Name, key, StringComparison.OrdinalIgnoreCase));
+        public static IEnumerable<JsonProperty> GetPropertiesByName(this JsonDocument json, string propertyName)
+            => json.RootElement.AllProperties().Where(property => string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+
+        public static IEnumerable<JsonProperty> GetPropertiesByName(this JsonProperty property, string propertyName)
+            => property.Value.AllProperties().Where(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
 
         private static IEnumerable<(JsonProperty element, JsonProperty? parent)> GetByKeyWithParent(this JsonDocument json, string key)
             => json.RootElement.AllPropertiesWithParent().Where(pair => string.Equals(pair.property.Name, key, StringComparison.OrdinalIgnoreCase));
 
         private static IEnumerable<JsonProperty> AllProperties(this JsonElement obj)
             => obj.AllPropertiesWithParent().Select(pair => pair.property);
+
+        private static IEnumerable<string> GetStringValues(IEnumerable<JsonProperty> properties)
+        {
+            if (!properties.Any())
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            var first = properties.First();
+            switch (first.Value.ValueKind)
+            {
+                case JsonValueKind.String:
+                    return new[] { first.Value.GetString() ?? "" };
+                case JsonValueKind.Array:
+                    return first.Value.EnumerateArray().Where(c => c.ValueKind == JsonValueKind.String).Select(c => c.GetString() ?? "");
+                default:
+                    return Enumerable.Empty<string>();
+            }
+        }
+
 
         private static IEnumerable<(JsonProperty property, JsonProperty? parent)> AllPropertiesWithParent(this JsonElement obj)
         {

--- a/test/FluentAssertions.Web.Tests/BadRequestAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/BadRequestAssertionsSpecs.cs
@@ -33,19 +33,26 @@ namespace FluentAssertions.Web.Tests
         }
 
         #region HaveError
-        [Fact]
-        public void When_asserting_bad_request_response_with_standard_dot_net_json_content_to_be_BadRequest_and_have_error_field_and_error_message_it_should_succeed()
-        {
-            // Arrange
-            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
-            {
-                Content = new StringContent(@"{
+        [Theory]
+        [InlineData(@"{
                     ""errors"": {
                         ""Author"": [
                             ""The Author field is required.""
                         ]
                     }
-                }", Encoding.UTF8, "application/json")
+                }")]
+
+        [InlineData(@"{
+                        ""Author"": [
+                            ""The Author field is required.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_with_standard_dot_net_json_content_to_be_BadRequest_and_have_error_field_and_error_message_it_should_succeed(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -57,18 +64,103 @@ namespace FluentAssertions.Web.Tests
         }
 
         [Fact]
-        public void When_asserting_bad_request_response_without_a_containing_error_to_be_BadRequest_and_HaveError_it_should_throw_with_descriptive_message()
+        public void When_asserting_bad_request_response_with_error_field_having_a_reserved_name_from_standard_dot_net_json_to_be_BadRequest_and_HaveError_should_succeed()
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
                 Content = new StringContent(@"{
+                  ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
+                  ""title"": ""One or more validation errors occurred."",
+                  ""status"": 400,
+                  ""traceId"": ""00-deb7480af23a884e942f7b85cac6bd35-c1abe72874d40c4a-00"",
+                  ""errors"": {
+                    ""Status"": [
+                      ""Cannot add at Revoked Status.""
+                    ]
+                  }
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveError("Status", "Cannot add at Revoked Status.");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_bad_request_response_with_error_field_having_a_reserved_name_from_standard_dot_net_json_and_also_error_message_to_be_BadRequest_and_HaveError_should_succeed()
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(@"{
+                  ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
+                  ""title"": ""One or more validation errors occurred."",
+                  ""status"": 400,
+                  ""traceId"": ""00-deb7480af23a884e942f7b85cac6bd35-c1abe72874d40c4a-00"",
+                  ""errors"": {
+                    ""Status"": [
+                      ""2""
+                    ]
+                  }
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveError("status", "2");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_bad_request_response_with_error_field_having_a_reserved_name_from_standard_dot_net_json_which_does_not_exist_in_the_errors_property_to_be_BadRequest_and_HaveError_should_fail()
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(@"{
+                  ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
+                  ""title"": ""One or more validation errors occurred."",
+                  ""status"": 400,
+                  ""traceId"": ""00-deb7480af23a884e942f7b85cac6bd35-c1abe72874d40c4a-00"",
+                  ""errors"": {
+                  }
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveError("status", "400");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*to contain*status*field, but was not found*");
+        }
+
+        [Theory]
+        [InlineData(@"{
                     ""errors"": {
                         ""Author"": [
                             ""The Author field is required.""
                         ]
                     }
-                }", Encoding.UTF8, "application/json")
+                }")]
+        [InlineData(@"{
+                        ""Author"": [
+                            ""The Author field is required.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_without_a_containing_error_to_be_BadRequest_and_HaveError_it_should_throw_with_descriptive_message(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -80,19 +172,26 @@ namespace FluentAssertions.Web.Tests
                 .WithMessage("*to contain*Comments*field, but was not found*");
         }
 
-        [Fact]
-        public void When_asserting_bad_request_response_be_BadRequest_and_match_error_message_by_pattern_it_should_succeed()
-        {
-            // Arrange
-            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
-            {
-                Content = new StringContent(@"{
+        [Theory]
+        [InlineData(@"{
                     ""errors"": {
                         ""Author"": [
                             ""The Author field is required.""
                         ]
                     }
-                }", Encoding.UTF8, "application/json")
+                }")]
+
+        [InlineData(@"{
+                        ""Author"": [
+                            ""The Author field is required.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_be_BadRequest_and_match_error_message_by_pattern_it_should_succeed(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -103,15 +202,22 @@ namespace FluentAssertions.Web.Tests
             act.Should().NotThrow();
         }
 
-        [Fact]
-        public void When_asserting_bad_request_response_with_multiple_error_messages_to_be_BadRequest_and_have_error_field_and_error_message_and_also_having_another_error_message_it_should_succeed()
+        [Theory]
+        [InlineData(@"{
+                        ""id"": [""Error message 1."", ""Error message 2.""]   
+                    }")]
+        [InlineData(@"{
+                    ""errors"" :
+                        {
+                            ""id"": [""Error message 1."", ""Error message 2.""]   
+                        }
+        }")]
+        public void When_asserting_bad_request_response_with_multiple_error_messages_to_be_BadRequest_and_have_error_field_and_error_message_and_also_having_another_error_message_it_should_succeed(string responseContent)
         {
             // Arrange
             using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
-                Content = new StringContent(@"{
-                        ""id"": [""Error message 1."", ""Error message 2.""]   
-                    }", Encoding.UTF8, "application/json")
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -124,15 +230,22 @@ namespace FluentAssertions.Web.Tests
             act.Should().NotThrow();
         }
 
-        [Fact]
-        public void When_asserting_bad_request_response_with_the_errors_messages_as_a_single_field_to_be_BadRequest_and_have_error_field_and_error_message_it_should_succeed()
+        [Theory]
+        [InlineData(@"{
+                        ""Author"": ""The Author field is required.""
+                }")]
+
+        [InlineData(@"{
+                    ""errors"" : {
+                        ""Author"": ""The Author field is required.""
+                }
+        }")]
+        public void When_asserting_bad_request_response_with_the_errors_messages_as_a_single_field_to_be_BadRequest_and_have_error_field_and_error_message_it_should_succeed(string responseContent)
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
-                Content = new StringContent(@"{
-                        ""Author"": ""The Author field is required.""
-                }", Encoding.UTF8, "application/json")
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -143,19 +256,26 @@ namespace FluentAssertions.Web.Tests
             act.Should().NotThrow();
         }
 
-        [Fact]
-        public void
-            When_asserting_bad_request_response_with_a_response_content_having_an_array_to_BeBadRequest_and_have_error_field_and_error_message_it_should_throw_with_descriptive_message()
-        {
-            // Arrange
-            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
-            {
-                Content = new StringContent(@"  [
+        [Theory]
+        [InlineData(@"[
                         {
                             ""code"": ""previous_steps_validation_error"",
                             ""description"": null
                         }
-                    ]", Encoding.UTF8, "application/json")
+                    ]")]
+
+        [InlineData(@"{ ""errors"" : [
+                        {
+                            ""code"": ""previous_steps_validation_error"",
+                            ""description"": null
+                        }
+                    ] }")]
+        public void When_asserting_bad_request_response_with_a_response_content_having_an_array_to_BeBadRequest_and_have_error_field_and_error_message_it_should_throw_with_descriptive_message(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -246,6 +366,44 @@ namespace FluentAssertions.Web.Tests
         }
 
         [Fact]
+        public void When_asserting_bad_request_response_with_the_errors_messages_as_a_single_field_to_be_BadRequest_and_HaveErrorMessage_it_should_succeed()
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(@"{
+                        ""Author"": ""The Author field is required.""
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveErrorMessage("The Author field is required.");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_bad_request_response_with_a_list_errors_messages_to_be_BadRequest_and_HaveErrorMessage_it_should_succeed()
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(@"{
+                        ""Author"": [ ""The Author field is required."" ]
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveErrorMessage("The Author field is required.");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_asserting_bad_request_response_with_content_generated_by_AspNetCore22_to_be_BadRequest_with_specific_message_it_should_succeed()
         {
             // Arrange
@@ -274,16 +432,16 @@ namespace FluentAssertions.Web.Tests
             using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
                 Content = new StringContent(@"{
-        ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
-        ""title"": ""One or more validation errors occurred."",
-        ""status"": 400,
-        ""traceId"": ""|2e128730-44b8587a25408f28."",
-        ""errors"": {
-                ""$"": [
-                    ""The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. Path: $ | LineNumber: 0 | BytePositionInLine: 0.""
-            ]
-    }
-}", Encoding.UTF8, "application/json")
+                        ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
+                        ""title"": ""One or more validation errors occurred."",
+                        ""status"": 400,
+                        ""traceId"": ""|2e128730-44b8587a25408f28."",
+                        ""errors"": {
+                                ""$"": [
+                                    ""The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. Path: $ | LineNumber: 0 | BytePositionInLine: 0.""
+                            ]
+                    }
+                }", Encoding.UTF8, "application/json")
             };
 
             // Act 
@@ -293,6 +451,31 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_bad_request_response_with_error_field_having_a_reserved_name_from_standard_dot_net_json_which_does_not_exist_in_the_errors_property_to_be_BadRequest_and_HaveErrorMessage_should_fail()
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(@"{
+                  ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
+                  ""title"": ""One or more validation errors occurred."",
+                  ""status"": 400,
+                  ""traceId"": ""00-deb7480af23a884e942f7b85cac6bd35-c1abe72874d40c4a-00"",
+                  ""errors"": {
+                  }
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.HaveErrorMessage("One or more validation errors occurred.");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Expected response to contain the error message \"One or more validation errors occurred.\", but no such message was found in the actual error messages list*");
         }
 
         [Theory]
@@ -323,19 +506,25 @@ namespace FluentAssertions.Web.Tests
         #endregion
 
         #region NotHaveError
-        [Fact]
-        public void When_asserting_bad_request_response_with_standard_dot_net_json_content_to_be_BadRequest_and_NotHaveError_it_should_succeed()
-        {
-            // Arrange
-            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
-            {
-                Content = new StringContent(@"{
+        [Theory]
+        [InlineData(@"{
                     ""errors"": {
                         ""Author"": [
                             ""The Author field is required.""
                         ]
                     }
-                }", Encoding.UTF8, "application/json")
+                }")]
+        [InlineData(@"{
+                        ""Author"": [
+                            ""The Author field is required.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_with_standard_to_be_BadRequest_and_NotHaveError_it_should_succeed(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -347,18 +536,52 @@ namespace FluentAssertions.Web.Tests
         }
 
         [Fact]
-        public void When_asserting_bad_request_response_with_a_containing_error_to_be_BadRequest_and_NotHaveError_it_should_throw_with_descriptive_message()
+        public void When_asserting_bad_request_response_with_error_field_having_a_reserved_name_from_standard_dot_net_json_which_does_not_exist_in_the_errors_property_to_be_BadRequest_and_NotHaveError_should_succeed()
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
                 Content = new StringContent(@"{
+                  ""type"": ""https://tools.ietf.org/html/rfc7231#section-6.5.1"",
+                  ""title"": ""One or more validation errors occurred."",
+                  ""status"": 400,
+                  ""traceId"": ""00-deb7480af23a884e942f7b85cac6bd35-c1abe72874d40c4a-00"",
+                  ""errors"": {
+                         ""Author"": [
+                                            ""The Author field is required.""
+                                     ]
+                  }
+                }", Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.NotHaveError("status");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [InlineData(@"{
                     ""errors"": {
                         ""Author"": [
                             ""The Author field is required.""
                         ]
                     }
-                }", Encoding.UTF8, "application/json")
+                }")]
+
+        [InlineData(@"{
+                        ""Author"": [
+                            ""The Author field is required.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_with_a_containing_error_to_be_BadRequest_and_NotHaveError_it_should_throw_with_descriptive_message(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -398,19 +621,21 @@ namespace FluentAssertions.Web.Tests
         #endregion
 
         #region OnlyHaveError
-        [Fact]
-        public void When_asserting_bad_request_response_with_a_single_error_field_to_be_BadRequest_and_OnlyHaveError_for_that_field_it_should_succeed()
+        [Theory]
+        [InlineData(@"{
+                    ""errors"": {
+                        ""Author"": [ ""The Author field is required."" ]
+                    }
+                }")]
+        [InlineData(@"{
+                    ""Author"": [ ""The Author field is required."" ]
+                    }")]
+        public void When_asserting_bad_request_response_with_a_single_error_field_to_be_BadRequest_and_OnlyHaveError_for_that_field_it_should_succeed(string responseContent)
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
-                Content = new StringContent(@"{
-                    ""errors"": {
-                        ""Author"": [
-                            ""The Author field is required.""
-                        ]
-                    }
-                }", Encoding.UTF8, "application/json")
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -421,22 +646,23 @@ namespace FluentAssertions.Web.Tests
             act.Should().NotThrow();
         }
 
-        [Fact]
-        public void When_asserting_bad_request_response_with_multiple_error_fields_where_one_of_them_is_the_actual_error_to_be_BadRequest_and_OnlyHaveError_fo_it_should_throw_with_descriptive_message()
+        [Theory]
+        [InlineData(@"{
+                    ""errors"": {
+                        ""Author"": [ ""The Author field is required."" ],
+                        ""Comments"": [ ""The Comments field is required."" ]
+                    }
+                }")]
+        [InlineData(@"{
+                    ""Author"": [ ""The Author field is required."" ],
+                    ""Comments"": [ ""The Comments field is required."" ]
+                }")]
+        public void When_asserting_bad_request_response_with_multiple_error_fields_where_one_of_them_is_the_actual_error_from_standard_dot_net_json_to_be_BadRequest_and_OnlyHaveError_fo_it_should_throw_with_descriptive_message(string responseContent)
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
-                Content = new StringContent(@"{
-                    ""errors"": {
-                        ""Author"": [
-                            ""The Author field is required.""
-                        ],
-                        ""Comments"": [
-                            ""The Comments field is required.""
-                        ]
-                    }
-                }", Encoding.UTF8, "application/json")
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act
@@ -448,13 +674,40 @@ namespace FluentAssertions.Web.Tests
                 .WithMessage("*author*but more than this one was found.*");
         }
 
-        [Fact]
-        public void When_asserting_bad_request_response_with_multiple_error_fields_where_none_one_of_them_is_the_actual_error_to_be_BadRequest_and_OnlyHaveError_it_should_throw_with_descriptive_message()
+        [Theory]
+        [InlineData(@"{
+                    ""errors"": {
+                        ""Author"": [
+                            ""Message 1."",
+                            ""Message 2.""
+                        ]
+                    }
+                }")]
+        [InlineData(@"{
+                        ""Author"": [
+                            ""Message 1."",
+                            ""Message 2.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_with_multiple_error_messages_where_one_of_them_is_the_actual_error_from_standard_dot_net_json_to_be_BadRequest_and_OnlyHaveError_fo_it_should_throw_with_descriptive_message(string responseContent)
         {
             // Arrange
             using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
-                Content = new StringContent(@"{
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
+            };
+
+            // Act
+            Action act = () => subject.Should().Be400BadRequest()
+                .And.OnlyHaveError("Author", "*Message 1*");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*author* field and message *Message 1*but more than this one was found.*");
+        }
+
+        [Theory]
+        [InlineData(@"{
                     ""errors"": {
                         ""Author"": [
                             ""The Author field is required.""
@@ -463,7 +716,21 @@ namespace FluentAssertions.Web.Tests
                             ""The Comments field is required.""
                         ]
                     }
-                }", Encoding.UTF8, "application/json")
+                }")]
+        [InlineData(@"{
+                        ""Author"": [
+                            ""The Author field is required.""
+                        ],
+                        ""Comments"": [
+                            ""The Comments field is required.""
+                        ]
+                }")]
+        public void When_asserting_bad_request_response_with_multiple_error_fields_where_none_one_of_them_is_the_actual_error_to_be_BadRequest_and_OnlyHaveError_it_should_throw_with_descriptive_message(string responseContent)
+        {
+            // Arrange
+            using var subject = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(responseContent, Encoding.UTF8, "application/json")
             };
 
             // Act

--- a/test/FluentAssertions.Web.Tests/Internal/JsonExtensionsTests.cs
+++ b/test/FluentAssertions.Web.Tests/Internal/JsonExtensionsTests.cs
@@ -6,104 +6,7 @@ namespace FluentAssertions.Web.Tests.Internal
 {
     public class JsonExtensionsTests
     {
-        #region HasKey
-        [Fact]
-        public void GivenJsonWithAKey_WhenHasKeyIsCalledWithThatKeyName_ThenReturnsTrue()
-        {
-            // Arrange
-            using var json = JsonDocument.Parse(@"{
-                ""errors"": {
-                    ""Author"": [
-                        ""The Author field is required.""
-                    ]
-                }
-            }");
-
-            // Act
-            var result = json.HasKey("Author");
-
-            // Assert
-            result.Should().BeTrue();
-        }
-
-        [Fact]
-        public void GivenJsonWithAKey_WhenHasKeyIsCalledWithADifferentKeyName_ThenReturnsFalse()
-        {
-            // Arrange
-            using var json = JsonDocument.Parse(@"{
-                ""errors"": {
-                    ""Comment"": [
-                        ""The Comment field is required.""
-                    ]
-                }
-            }");
-
-            // Act
-            var result = json.HasKey("Author");
-
-            // Assert
-            result.Should().BeFalse();
-        }
-
-        [Fact]
-        public void GivenJsonWithAnEmptyKey_WhenHasKeyIsCalledWithEmptyKey_ThenReturnsTrue()
-        {
-            // Arrange
-            using var json = JsonDocument.Parse(@"{
-                ""errors"": {
-                    """": [
-                        ""A non-empty request body is required.""
-                    ]
-                }
-            }");
-
-            // Act
-            var result = json.HasKey("");
-
-            // Assert
-            result.Should().BeTrue();
-        }
-
-        [Fact]
-        public void GivenJsonWithoutAnEmptyKey_WhenHasKeyIsCalledWithEmptyKey_ThenReturnsFalse()
-        {
-            // Arrange
-            using var json = JsonDocument.Parse(@"{
-                ""errors"": {
-                    ""Comment"": [
-                        ""The Comment field is required.""
-                    ]
-                }
-            }");
-
-            // Act
-            var result = json.HasKey("");
-
-            // Assert
-            result.Should().BeFalse();
-        }
-
-        [Fact]
-        public void GivenJsonWithAKey_WhenHasKeyIsCalledWithThatKeyNameButInDifferentCase_ThenReturnsTrue()
-        {
-            // Arrange
-            using var json = JsonDocument.Parse(@"{
-                ""errors"": {
-                    ""Author"": [
-                        ""The Author field is required.""
-                    ]
-                }
-            }");
-
-            // Act
-            var result = json.HasKey("author");
-
-            // Assert
-            result.Should().BeTrue();
-        }
-        #endregion
-
-        #region GetStringValuesByKey
+        #region GetStringValuesOf
         [Fact]
         public void GivenJson_WhenKeyExistsAndHasAnArrayOfStringValues_ThenReturnsTheStrings()
         {
@@ -118,7 +21,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEquivalentTo(new[] { "The Author field is required.", "The Author length exceeds 200 characters." });
@@ -138,7 +41,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEmpty();
@@ -158,7 +61,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEmpty();
@@ -177,7 +80,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Comment");
+            var result = json.GetStringValuesOf("Comment");
 
             // Assert
             result.Should().BeEmpty();
@@ -194,7 +97,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEquivalentTo(new[] { "The Author field is required." });
@@ -211,7 +114,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEmpty();
@@ -228,7 +131,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEmpty();
@@ -245,7 +148,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEmpty();
@@ -262,14 +165,14 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEmpty();
         }
         #endregion
 
-        #region GetChildrenKeys
+        #region GetChildrenNames
         [Fact]
         public void GivenJsonWithAField_WhenGetChildrenKeysIsCalledWithThatField_ThenReturnsDirectKeys()
         {
@@ -286,7 +189,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetChildrenKeys("errors");
+            var result = json.GetChildrenNames("errors");
 
             // Assert
             result.Should().BeEquivalentTo("Author", "Content");
@@ -305,7 +208,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetChildrenKeys("errors");
+            var result = json.GetChildrenNames("errors");
 
             // Assert
             result.Should().BeEquivalentTo("");
@@ -322,7 +225,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetChildrenKeys("");
+            var result = json.GetChildrenNames("");
 
             // Assert
             result.Should().BeEquivalentTo("Author");
@@ -345,7 +248,7 @@ namespace FluentAssertions.Web.Tests.Internal
             }");
 
             // Act
-            var result = json.GetStringValuesByKey("Author");
+            var result = json.GetStringValuesOf("Author");
 
             // Assert
             result.Should().BeEquivalentTo(new[] { "The Author field is required." });


### PR DESCRIPTION
Given the following json

{
  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "traceId": "00-deb7480af23a884e942f7b85cac6bd35-c1abe72874d40c4a-00",
  "errors": {
	"Status": [
	  "Cannot add at Revoked Status."
	]
  }
}

then HaveError("Status", "Cannot add at Revoked Status.") would not
correctly verify the assertion, as it considered the "status"
property from above ("status": 400)