### PR TITLE
Ensure SUT's variable name is logged

### DIFF
--- a/src/FluentAssertions.Web/BadRequestAssertions.cs
+++ b/src/FluentAssertions.Web/BadRequestAssertions.cs
@@ -48,6 +48,7 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<BadRequestAssertions> HaveError(string expectedErrorField, string expectedWildcardErrorMessage,
             string because = "", params object[] becauseArgs)
         {
@@ -112,6 +113,8 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+
+        [CustomAssertion]
         public AndConstraint<BadRequestAssertions> OnlyHaveError(string expectedErrorField, string expectedWildcardErrorMessage,
             string because = "", params object[] becauseArgs)
         {
@@ -192,6 +195,8 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+
+        [CustomAssertion]
         public AndConstraint<BadRequestAssertions> NotHaveError(string expectedErrorField, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNullOrEmpty(expectedErrorField, nameof(expectedErrorField), "Cannot verify not having an error against a <null> or empty field name.");
@@ -228,6 +233,8 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+
+        [CustomAssertion]
         public AndConstraint<BadRequestAssertions> HaveErrorMessage(string expectedWildcardErrorMessage,
             string because = "", params object[] becauseArgs)
         {

--- a/src/FluentAssertions.Web/BadRequestAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/BadRequestAssertionsExtensions.cs
@@ -29,6 +29,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<BadRequestAssertions> HaveError(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -56,6 +57,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<BadRequestAssertions> OnlyHaveError(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -80,6 +82,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<BadRequestAssertions> NotHaveError(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -100,6 +103,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<BadRequestAssertions> HaveErrorMessage(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,

--- a/src/FluentAssertions.Web/HaveHeaderAssertions.cs
+++ b/src/FluentAssertions.Web/HaveHeaderAssertions.cs
@@ -35,11 +35,15 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HeadersAssertions> Match(string expectedWildcardValue, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expectedWildcardValue, nameof(expectedWildcardValue), "Cannot verify a HTTP header to be a value against a <null> value. Use And.BeEmpty to test if the HTTP header has no values.");
 
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
             IEnumerable<string> headerValues = Subject.GetHeaderValues(_header);
 
@@ -53,7 +57,7 @@ namespace FluentAssertions.Web
             Execute.Assertion
                          .BecauseOf(because, becauseArgs)
                          .ForCondition(matchFound)
-                         .FailWith("Expected {context:value} to contain " +
+                         .FailWith("Expected {context:response} to contain " +
                                    "the HTTP header {0} having a value matching {1}, but there was no match{reason}. {2}",
                              _header,
                              expectedWildcardValue,
@@ -72,6 +76,7 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HeadersAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             var headerValues = Subject.GetHeaderValues(_header);
@@ -79,7 +84,7 @@ namespace FluentAssertions.Web
             Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .ForCondition(!headerValues.Any())
-                        .FailWith("Expected {context:value} to contain " +
+                        .FailWith("Expected {context:response} to contain " +
                                   "the HTTP header {0} with no header values, but the found the header and it has values {1} in the actual response{reason}. {2}",
                             _header,
                             headerValues,
@@ -101,6 +106,7 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HeadersAssertions> BeValues(IEnumerable<string> expectedValues,
             string because = "", params object[] becauseArgs)
         {
@@ -124,7 +130,7 @@ namespace FluentAssertions.Web
             Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .ForCondition(failures.Length == 0)
-                        .FailWith("Expected {context:value} to contain " +
+                        .FailWith("Expected {context:response} to contain " +
                                   "the HTTP header {0} having values {1}, but the found values have differences{reason}. {2}",
                             _header,
                             expectedValues,
@@ -156,6 +162,7 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HeadersAssertions> HaveHeader(string expectedHeader,
             string because = "", params object[] becauseArgs)
         {
@@ -164,7 +171,7 @@ namespace FluentAssertions.Web
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(IsHeaderPresent(expectedHeader))
-                .FailWith("Expected {context:value} to contain " +
+                .FailWith("Expected {context:response} to contain " +
                           "the HTTP header {0}, but no such header was found in the actual response{reason}.{1}",
                     expectedHeader,
                     Subject);
@@ -185,6 +192,7 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> NotHaveHeader(string expectedHeader,
             string because = "", params object[] becauseArgs)
         {
@@ -193,7 +201,7 @@ namespace FluentAssertions.Web
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!IsHeaderPresent(expectedHeader))
-                .FailWith("Expected {context:value} to not to contain " +
+                .FailWith("Expected {context:response} to not to contain " +
                           "the HTTP header {0}, but the header was found in the actual response{reason}.{1}",
                     expectedHeader,
                     Subject);

--- a/src/FluentAssertions.Web/HaveHeaderAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HaveHeaderAssertionsExtensions.cs
@@ -22,6 +22,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HeadersAssertions> HaveHeader(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -43,6 +44,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> NotHaveHeader(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,

--- a/src/FluentAssertions.Web/HttpResponseContentAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HttpResponseContentAssertionsExtensions.cs
@@ -30,6 +30,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> BeAs<TModel>(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -50,6 +51,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> BeAs<TModel>(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -70,6 +72,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> MatchInContent(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,

--- a/src/FluentAssertions.Web/HttpResponseMessageAssertions.cs
+++ b/src/FluentAssertions.Web/HttpResponseMessageAssertions.cs
@@ -32,32 +32,6 @@ namespace FluentAssertions.Web
         /// </summary>
         protected override string Identifier => $"{nameof(HttpResponseMessage)}";
 
-        private protected void ExecuteSubjectNotNull(string because, object[] becauseArgs)
-        {
-            Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected an HTTP {context:response} to assert{reason}, but found <null>.");
-        }
-
-        private void ExecuteStatusAssertion(string because, object[] becauseArgs, HttpStatusCode expected, string? otherName = null)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(expected == Subject.StatusCode)
-                .FailWith("Expected HTTP {context:response} to be {0}{reason}, but found {1}.{2}"
-                    , otherName ?? expected.ToString(), Subject.StatusCode, Subject);
-        }
-
-        private void ExecuteModelExtractedAssertion(bool success, string? errorMessage, Type? modelType, string because, object[] becauseArgs)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(success)
-                .FailWith("Expected {context:response} to have a content equivalent to a model of type {0}, but the JSON representation could not be parsed, as the operation failed with the following message: {2}{reason}. {1}",
-                    modelType?.ToString() ?? "unknown type", Subject, errorMessage);
-        }
-
         private protected string? GetContent()
         {
             Func<Task<string?>> content = () => Subject.GetStringContent();

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertions.cs
@@ -17,16 +17,20 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public AndConstraint<HttpResponseMessageAssertions> Be1XXInformational(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.StatusCode < HttpStatusCode.OK)
+                .ForCondition(Subject!.StatusCode < HttpStatusCode.OK)
                 .FailWith("Expected {context:response} to have a HTTP status code representing an informational error, but it was {0}{reason}.{1}",
-                    Subject.StatusCode, Subject);
+                    Subject!.StatusCode, Subject);
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -44,16 +48,20 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public AndConstraint<HttpResponseMessageAssertions> Be2XXSuccessful(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.IsSuccessStatusCode)
+                .ForCondition(Subject!.IsSuccessStatusCode)
                 .FailWith("Expected {context:response} to have a successful HTTP status code, but it was {0}{reason}.{1}",
-                    Subject.StatusCode, Subject);
+                    Subject!.StatusCode, Subject);
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -71,16 +79,20 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public AndConstraint<HttpResponseMessageAssertions> Be3XXRedirection(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.StatusCode >= HttpStatusCode.Moved && Subject.StatusCode < HttpStatusCode.BadRequest)
+                .ForCondition(Subject!.StatusCode >= HttpStatusCode.Moved && Subject!.StatusCode < HttpStatusCode.BadRequest)
                 .FailWith("Expected {context:response} to have a HTTP status code representing a redirection, but it was {0}{reason}.{1}",
-                    Subject.StatusCode, Subject);
+                    Subject!.StatusCode, Subject);
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -98,16 +110,20 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public AndConstraint<HttpResponseMessageAssertions> Be4XXClientError(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.StatusCode >= HttpStatusCode.BadRequest && Subject.StatusCode < HttpStatusCode.InternalServerError)
+                .ForCondition(Subject!.StatusCode >= HttpStatusCode.BadRequest && Subject!.StatusCode < HttpStatusCode.InternalServerError)
                 .FailWith("Expected {context:response} to have a HTTP status code representing a client error, but it was {0}{reason}.{1}",
-                    Subject.StatusCode, Subject);
+                    Subject!.StatusCode, Subject);
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -125,16 +141,20 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public AndConstraint<HttpResponseMessageAssertions> Be5XXServerError(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.StatusCode >= HttpStatusCode.InternalServerError)
+                .ForCondition(Subject!.StatusCode >= HttpStatusCode.InternalServerError)
                 .FailWith("Expected {context:response} to have a HTTP status code representing a server error, but it was {0}{reason}.{1}",
-                    Subject.StatusCode, Subject);
+                    Subject!.StatusCode, Subject);
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -154,10 +174,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> HaveHttpStatusCode(HttpStatusCode expected, string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, expected);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(expected == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , expected, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
         #endregion
@@ -176,14 +205,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> NotHaveHttpStatusCode(HttpStatusCode unexpected, string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(unexpected != Subject.StatusCode)
+                .ForCondition(unexpected != Subject!.StatusCode)
                 .FailWith("Did not expect {context:response} to have status {0}{reason}.{1}",
-                    Subject.StatusCode, Subject);
+                    Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
         #endregion
@@ -199,10 +233,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be100Continue(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Continue);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Continue == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Continue, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -216,10 +259,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be101SwitchingProtocols(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.SwitchingProtocols);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.SwitchingProtocols == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.SwitchingProtocols, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -233,10 +285,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be200Ok(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.OK);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.OK == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.OK, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -250,10 +311,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be201Created(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Created);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Created == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Created, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -267,10 +337,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be202Accepted(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Accepted);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Accepted == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Accepted, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -284,10 +363,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be203NonAuthoritativeInformation(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.NonAuthoritativeInformation);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.NonAuthoritativeInformation == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.NonAuthoritativeInformation, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -301,10 +389,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be204NoContent(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.NoContent);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.NoContent == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.NoContent, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -318,10 +415,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be205ResetContent(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.ResetContent);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.ResetContent == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.ResetContent, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -335,10 +441,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be206PartialContent(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.PartialContent);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.PartialContent == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.PartialContent, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -352,10 +467,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be300MultipleChoices(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.MultipleChoices, "MultipleChoices");
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.MultipleChoices == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , "HttpStatusCode.MultipleChoices {value: 300}", Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -369,10 +493,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be300Ambiguous(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Ambiguous);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Ambiguous == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Ambiguous, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -386,10 +519,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be301MovedPermanently(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.MovedPermanently, "MovedPermanently");
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.MovedPermanently == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , "HttpStatusCode.MovedPermanently {value: 301}", Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -403,10 +545,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be301Moved(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Moved);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Moved == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Moved, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -420,10 +571,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be302Found(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Found, "Found");
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Found == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , "HttpStatusCode.Found {value: 302}", Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -437,10 +597,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be302Redirect(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Redirect, "Redirect");
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Redirect == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Redirect, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -454,10 +623,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be303SeeOther(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.SeeOther, "SeeOther");
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.SeeOther == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , "HttpStatusCode.SeeOther {value: 303}", Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -471,10 +649,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be303RedirectMethod(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.RedirectMethod);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.RedirectMethod == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.RedirectMethod, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -488,10 +675,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be304NotModified(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.NotModified);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.NotModified == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.NotModified, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -505,10 +701,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be305UseProxy(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.UseProxy);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.UseProxy == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.UseProxy, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -522,10 +727,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be306Unused(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Unused);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Unused == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Unused, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -539,10 +753,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be307TemporaryRedirect(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.TemporaryRedirect);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.TemporaryRedirect == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.TemporaryRedirect, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -556,10 +779,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be307RedirectKeepVerb(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.RedirectKeepVerb, "RedirectKeepVerb");
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.RedirectKeepVerb == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , "HttpStatusCode.RedirectKeepVerb {value: 307}", Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -573,10 +805,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<BadRequestAssertions> Be400BadRequest(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.BadRequest);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.BadRequest == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.BadRequest, Subject!.StatusCode, Subject);
             return new AndConstraint<BadRequestAssertions>(new BadRequestAssertions(Subject));
         }
 
@@ -590,10 +831,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be401Unauthorized(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Unauthorized);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Unauthorized == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Unauthorized, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -607,10 +857,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be402PaymentRequired(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.PaymentRequired);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.PaymentRequired == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.PaymentRequired, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -624,10 +883,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be403Forbidden(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Forbidden);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Forbidden == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Forbidden, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -641,10 +909,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be404NotFound(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.NotFound);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.NotFound == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.NotFound, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -658,10 +935,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be405MethodNotAllowed(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.MethodNotAllowed);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.MethodNotAllowed == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.MethodNotAllowed, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -675,10 +961,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be406NotAcceptable(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.NotAcceptable);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.NotAcceptable == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.NotAcceptable, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -692,10 +987,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be407ProxyAuthenticationRequired(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.ProxyAuthenticationRequired);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.ProxyAuthenticationRequired == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.ProxyAuthenticationRequired, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -709,10 +1013,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be408RequestTimeout(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.RequestTimeout);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.RequestTimeout == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.RequestTimeout, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -726,10 +1039,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be409Conflict(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Conflict);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Conflict == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Conflict, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -743,10 +1065,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be410Gone(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.Gone);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.Gone == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.Gone, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -760,10 +1091,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be411LengthRequired(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.LengthRequired);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.LengthRequired == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.LengthRequired, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -777,10 +1117,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be412PreconditionFailed(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.PreconditionFailed);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.PreconditionFailed == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.PreconditionFailed, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -794,10 +1143,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be413RequestEntityTooLarge(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.RequestEntityTooLarge);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.RequestEntityTooLarge == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.RequestEntityTooLarge, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -811,10 +1169,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be414RequestUriTooLong(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.RequestUriTooLong);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.RequestUriTooLong == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.RequestUriTooLong, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -828,10 +1195,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be415UnsupportedMediaType(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.UnsupportedMediaType);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.UnsupportedMediaType == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.UnsupportedMediaType, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -845,10 +1221,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be416RequestedRangeNotSatisfiable(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.RequestedRangeNotSatisfiable);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.RequestedRangeNotSatisfiable == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.RequestedRangeNotSatisfiable, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -862,10 +1247,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be417ExpectationFailed(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.ExpectationFailed);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.ExpectationFailed == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.ExpectationFailed, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -879,10 +1273,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be426UpgradeRequired(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.UpgradeRequired);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.UpgradeRequired == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.UpgradeRequired, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -896,10 +1299,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be500InternalServerError(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.InternalServerError);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.InternalServerError == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.InternalServerError, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -913,10 +1325,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be501NotImplemented(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.NotImplemented);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.NotImplemented == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.NotImplemented, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -930,10 +1351,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be502BadGateway(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.BadGateway);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.BadGateway == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.BadGateway, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -947,10 +1377,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be503ServiceUnavailable(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.ServiceUnavailable);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.ServiceUnavailable == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.ServiceUnavailable, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -964,10 +1403,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be504GatewayTimeout(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.GatewayTimeout);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.GatewayTimeout == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.GatewayTimeout, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
 
@@ -981,10 +1429,19 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Be505HttpVersionNotSupported(string because = "", params object[] becauseArgs)
         {
-            ExecuteSubjectNotNull(because, becauseArgs);
-            ExecuteStatusAssertion(because, becauseArgs, HttpStatusCode.HttpVersionNotSupported);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(HttpStatusCode.HttpVersionNotSupported == Subject!.StatusCode)
+                .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                    , HttpStatusCode.HttpVersionNotSupported, Subject!.StatusCode, Subject);
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
         #endregion

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
@@ -21,6 +21,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public static AndConstraint<HttpResponseMessageAssertions> Be1XXInformational(
 #pragma warning disable 1573
@@ -42,6 +43,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public static AndConstraint<HttpResponseMessageAssertions> Be2XXSuccessful(
 #pragma warning disable 1573
@@ -63,6 +65,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public static AndConstraint<HttpResponseMessageAssertions> Be3XXRedirection(
 #pragma warning disable 1573
@@ -84,6 +87,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public static AndConstraint<HttpResponseMessageAssertions> Be4XXClientError(
 #pragma warning disable 1573
@@ -105,6 +109,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         // ReSharper disable once InconsistentNaming
         public static AndConstraint<HttpResponseMessageAssertions> Be5XXServerError(
 #pragma warning disable 1573
@@ -128,6 +133,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> HaveHttpStatusCode(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -150,6 +156,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> NotHaveHttpStatusCode(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -169,6 +176,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be100Continue(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -186,6 +194,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be101SwitchingProtocols(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -203,6 +212,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be200Ok(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -220,6 +230,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be201Created(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -237,6 +248,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be202Accepted(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -254,6 +266,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be203NonAuthoritativeInformation(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -271,6 +284,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be204NoContent(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -288,6 +302,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be205ResetContent(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -305,6 +320,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be206PartialContent(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -322,6 +338,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be300MultipleChoices(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -339,6 +356,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be300Ambiguous(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -356,6 +374,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be301MovedPermanently(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -373,6 +392,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be301Moved(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -390,6 +410,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be302Found(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -407,6 +428,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be302Redirect(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -424,6 +446,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be303SeeOther(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -441,6 +464,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be303RedirectMethod(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -458,6 +482,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be304NotModified(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -475,6 +500,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be305UseProxy(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -492,6 +518,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be306Unused(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -509,6 +536,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be307TemporaryRedirect(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -526,6 +554,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be307RedirectKeepVerb(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -543,6 +572,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<BadRequestAssertions> Be400BadRequest(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -560,6 +590,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be401Unauthorized(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -577,6 +608,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be402PaymentRequired(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -594,6 +626,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be403Forbidden(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -611,6 +644,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be404NotFound(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -628,6 +662,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be405MethodNotAllowed(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -645,6 +680,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be406NotAcceptable(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -662,6 +698,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be407ProxyAuthenticationRequired(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -679,6 +716,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be408RequestTimeout(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -696,6 +734,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be409Conflict(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -713,6 +752,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be410Gone(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -730,6 +770,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be411LengthRequired(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -747,6 +788,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be412PreconditionFailed(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -764,6 +806,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be413RequestEntityTooLarge(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -781,6 +824,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be414RequestUriTooLong(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -798,6 +842,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be415UnsupportedMediaType(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -815,6 +860,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be416RequestedRangeNotSatisfiable(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -832,6 +878,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be417ExpectationFailed(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -849,6 +896,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be426UpgradeRequired(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -866,6 +914,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be500InternalServerError(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -883,6 +932,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be501NotImplemented(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -900,6 +950,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be502BadGateway(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -917,6 +968,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be503ServiceUnavailable(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -934,6 +986,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be504GatewayTimeout(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -951,6 +1004,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Be505HttpVersionNotSupported(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,

--- a/src/FluentAssertions.Web/SatisfyHttpResponseMessageAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/SatisfyHttpResponseMessageAssertionsExtensions.cs
@@ -29,6 +29,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Satisfy(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -53,6 +54,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Satisfy(
 #pragma warning disable 1573
                 this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,

--- a/src/FluentAssertions.Web/SatisfyModelAssertions.cs
+++ b/src/FluentAssertions.Web/SatisfyModelAssertions.cs
@@ -24,15 +24,39 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(
             Action<TModel> assertion,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(assertion, nameof(assertion),
                 "Cannot verify the subject satisfies a `null` assertion.");
-            ExecuteSubjectNotNull(because, becauseArgs);
 
-            ExecuteSatisfyModelAssertions(assertion, because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            var (success, errorMessage) = TryGetSubjectModel<TModel>(out var model);
+
+            Type? modelType = typeof(TModel);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(success)
+                .FailWith("Expected {context:response} to have a content equivalent to a model of type {0}, but the JSON representation could not be parsed, as the operation failed with the following message: {2}{reason}. {1}",
+                    modelType?.ToString() ?? "unknown type", Subject, errorMessage);
+
+            var failuresFromAssertions = CollectFailuresFromAssertion(assertion, model);
+
+            if (failuresFromAssertions.Any())
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:response} to satisfy one or more model assertions, but it wasn't{reason}: {0}{1}",
+                        new AssertionsFailures(failuresFromAssertions), Subject);
+            }
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -56,14 +80,38 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(TModel givenModelStructure,
             Action<TModel> assertion,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(assertion, nameof(assertion), "Cannot verify the subject satisfies a `null` assertion.");
-            ExecuteSubjectNotNull(because, becauseArgs);
 
-            ExecuteSatisfyModelAssertions(assertion, because, becauseArgs);
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            var (success, errorMessage) = TryGetSubjectModel<TModel>(out var model);
+
+            Type? modelType = typeof(TModel);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(success)
+                .FailWith("Expected {context:response} to have a content equivalent to a model of type {0}, but the JSON representation could not be parsed, as the operation failed with the following message: {2}{reason}. {1}",
+                    modelType?.ToString() ?? "unknown type", Subject, errorMessage);
+
+            var failuresFromAssertions = CollectFailuresFromAssertion(assertion, model);
+
+            if (failuresFromAssertions.Any())
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:response} to satisfy one or more model assertions, but it wasn't{reason}: {0}{1}",
+                        new AssertionsFailures(failuresFromAssertions), Subject);
+            }
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -84,19 +132,44 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(
             Func<TModel, Task> assertion,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(assertion, nameof(assertion),
                 "Cannot verify the subject satisfies a `null` assertion.");
-            ExecuteSubjectNotNull(because, becauseArgs);
 
-            ExecuteSatisfyModelAssertions<TModel>(asserted =>
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Action<TModel> assertion1 = asserted =>
             {
                 Func<Task> assertionExecutor = () => assertion(asserted);
                 assertionExecutor.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
-            }, because, becauseArgs);
+            };
+            var (success, errorMessage) = TryGetSubjectModel<TModel>(out var model);
+
+            Type? modelType = typeof(TModel);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(success)
+                .FailWith("Expected {context:response} to have a content equivalent to a model of type {0}, but the JSON representation could not be parsed, as the operation failed with the following message: {2}{reason}. {1}",
+                    modelType?.ToString() ?? "unknown type", Subject, errorMessage);
+
+            var failuresFromAssertions = CollectFailuresFromAssertion(assertion1, model);
+
+            if (failuresFromAssertions.Any())
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:response} to satisfy one or more model assertions, but it wasn't{reason}: {0}{1}",
+                        new AssertionsFailures(failuresFromAssertions), Subject);
+            }
 
             return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
@@ -120,38 +193,45 @@ namespace FluentAssertions.Web
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(TModel givenModelStructure,
             Func<TModel, Task> assertion,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(assertion, nameof(assertion), "Cannot verify the subject satisfies a `null` assertion.");
-            ExecuteSubjectNotNull(because, becauseArgs);
 
-            ExecuteSatisfyModelAssertions<TModel>(model =>
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+            Action<TModel> assertion1 = model =>
             {
                 Func<Task> assertionExecutor = () => assertion(model);
                 assertionExecutor.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
-            }, because, becauseArgs);
+            };
+            var (success, errorMessage) = TryGetSubjectModel<TModel>(out var model1);
 
-            return new AndConstraint<HttpResponseMessageAssertions>(this);
-        }
-        
-        private protected void ExecuteSatisfyModelAssertions<TModel>(Action<TModel> assertion, string because, object[] becauseArgs)
-        {
-            var (success, errorMessage) = TryGetSubjectModel<TModel>(out var model);
+            Type? modelType = typeof(TModel);
 
-            ExecuteModelExtractedAssertion(success, errorMessage, typeof(TModel), because, becauseArgs);
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(success)
+                .FailWith("Expected {context:response} to have a content equivalent to a model of type {0}, but the JSON representation could not be parsed, as the operation failed with the following message: {2}{reason}. {1}",
+                    modelType?.ToString() ?? "unknown type", Subject, errorMessage);
 
-            var failuresFromAssertions = CollectFailuresFromAssertion(assertion, model);
+            var failuresFromAssertions = CollectFailuresFromAssertion(assertion1, model1);
 
             if (failuresFromAssertions.Any())
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Expected {context:value} to satisfy one or more model assertions, but it wasn't{reason}: {0}{1}",
+                        "Expected {context:response} to satisfy one or more model assertions, but it wasn't{reason}: {0}{1}",
                         new AssertionsFailures(failuresFromAssertions), Subject);
             }
+
+            return new AndConstraint<HttpResponseMessageAssertions>(this);
         }
     }
 }

--- a/src/FluentAssertions.Web/SatisfyModelAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/SatisfyModelAssertionsExtensions.cs
@@ -28,6 +28,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(
 #pragma warning disable 1573
                 this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -55,6 +56,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -80,6 +82,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
@@ -107,6 +110,7 @@ namespace FluentAssertions
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see paramref="because" />.
         /// </param>
+        [CustomAssertion]
         public static AndConstraint<HttpResponseMessageAssertions> Satisfy<TModel>(
 #pragma warning disable 1573
             this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,

--- a/test/FluentAssertions.Web.Tests/BadRequestAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/BadRequestAssertionsSpecs.cs
@@ -475,7 +475,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*Expected response to contain the error message \"One or more validation errors occurred.\", but no such message was found in the actual error messages list*");
+                .WithMessage("Expected * to contain the error message \"One or more validation errors occurred.\", but no such message was found in the actual error messages list*");
         }
 
         [Theory]

--- a/test/FluentAssertions.Web.Tests/HttpResponseContentAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpResponseContentAssertionsSpecs.cs
@@ -285,7 +285,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -373,7 +373,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
     }

--- a/test/FluentAssertions.Web.Tests/HttpStatusCodeAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpStatusCodeAssertionsSpecs.cs
@@ -55,7 +55,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -106,7 +106,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -158,7 +158,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -209,7 +209,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -260,7 +260,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -291,7 +291,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*BadRequest"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.BadRequest*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -306,7 +306,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -337,7 +337,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Did not expect *to have status HttpStatusCode.OK {value: 200}*message*");
+                .WithMessage(@"*Did not expect*to have status HttpStatusCode.OK {value: 200}*message*");
         }
 
         [Fact]
@@ -352,7 +352,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -383,7 +383,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Continue"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Continue*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -398,7 +398,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -429,7 +429,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*SwitchingProtocols"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.SwitchingProtocols*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -444,7 +444,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion 
 
@@ -475,7 +475,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*OK"" because we want to test the failure message, but found HttpStatusCode.BadRequest {value: 400}*");
+                .WithMessage(@"*HttpStatusCode.OK*because we want to test the failure message, but found HttpStatusCode.BadRequest {value: 400}*");
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -521,7 +521,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Created"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Created*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -536,7 +536,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -567,7 +567,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Accepted"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Accepted*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -582,7 +582,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -613,7 +613,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*NonAuthoritativeInformation"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.NonAuthoritativeInformation*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -628,7 +628,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -659,7 +659,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*NoContent"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.NoContent*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -674,7 +674,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -705,7 +705,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*ResetContent"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.ResetContent*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -720,7 +720,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -751,7 +751,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*PartialContent"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.PartialContent*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -766,7 +766,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -797,7 +797,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*MultipleChoices"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.MultipleChoices*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -812,7 +812,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -843,7 +843,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Ambiguous"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Ambiguous*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -858,7 +858,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -889,7 +889,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*MovedPermanently"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.MovedPermanently*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -904,7 +904,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -935,7 +935,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Moved"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Moved*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -950,7 +950,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -981,7 +981,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Found"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Found*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -996,7 +996,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1027,7 +1027,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Redirect"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Redirect*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1042,7 +1042,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1073,7 +1073,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*SeeOther"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.SeeOther*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1088,7 +1088,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1119,7 +1119,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*RedirectMethod"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.RedirectMethod*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1134,7 +1134,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1165,7 +1165,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*NotModified"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.NotModified*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1180,7 +1180,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1211,7 +1211,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*UseProxy"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.UseProxy*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1226,7 +1226,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1257,7 +1257,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Unused"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Unused*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1272,7 +1272,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1303,7 +1303,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*TemporaryRedirect"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.TemporaryRedirect*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1318,7 +1318,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1349,7 +1349,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*RedirectKeepVerb"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.RedirectKeepVerb*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1364,7 +1364,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion 
 
@@ -1395,7 +1395,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*BadRequest"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.BadRequest*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1410,7 +1410,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1441,7 +1441,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Unauthorized"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Unauthorized*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1456,7 +1456,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1487,7 +1487,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*PaymentRequired"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.PaymentRequired*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1502,7 +1502,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1533,7 +1533,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Forbidden"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Forbidden*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1548,7 +1548,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1579,7 +1579,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*NotFound"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.NotFound*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1594,7 +1594,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1625,7 +1625,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*MethodNotAllowed"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.MethodNotAllowed*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1640,7 +1640,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1671,7 +1671,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*NotAcceptable"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.NotAcceptable*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1686,7 +1686,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1717,7 +1717,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*ProxyAuthenticationRequired"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.ProxyAuthenticationRequired*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1732,7 +1732,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1763,7 +1763,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*RequestTimeout"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.RequestTimeout*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1778,7 +1778,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1809,7 +1809,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Conflict"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Conflict*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1824,7 +1824,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1855,7 +1855,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Gone"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.Gone*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1870,7 +1870,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1901,7 +1901,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*LengthRequired"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.LengthRequired*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1916,7 +1916,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1947,7 +1947,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*PreconditionFailed"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.PreconditionFailed*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -1962,7 +1962,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -1993,7 +1993,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*RequestEntityTooLarge"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.RequestEntityTooLarge*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2008,7 +2008,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2039,7 +2039,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*RequestUriTooLong"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.RequestUriTooLong*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2054,7 +2054,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2085,7 +2085,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*UnsupportedMediaType"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.UnsupportedMediaType*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2100,7 +2100,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2131,7 +2131,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*RequestedRangeNotSatisfiable"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.RequestedRangeNotSatisfiable*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2146,7 +2146,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2177,7 +2177,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*ExpectationFailed"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.ExpectationFailed*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2192,7 +2192,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2223,7 +2223,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*UpgradeRequired"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.UpgradeRequired*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2238,7 +2238,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2269,7 +2269,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*InternalServerError"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.InternalServerError*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2284,7 +2284,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2315,7 +2315,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*NotImplemented"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.NotImplemented*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2330,7 +2330,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2361,7 +2361,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*BadGateway"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.BadGateway*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2376,7 +2376,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2407,7 +2407,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*ServiceUnavailable"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.ServiceUnavailable*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2422,7 +2422,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2453,7 +2453,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*GatewayTimeout"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.GatewayTimeout*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2468,7 +2468,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -2499,7 +2499,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*HttpVersionNotSupported"" because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+                .WithMessage(@"*HttpStatusCode.HttpVersionNotSupported*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
         }
 
         [Fact]
@@ -2514,7 +2514,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion 
     }

--- a/test/FluentAssertions.Web.Tests/SatisfyHttpResponseMessageAssertionsAsyncSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/SatisfyHttpResponseMessageAssertionsAsyncSpecs.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*{empty} to contain \"byte\"*HTTP response*");
+                .WithMessage("Expected * to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*{empty} to contain \"byte\"*HTTP response*");
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"Expected value to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*""byte""*expected*to be <null>*The HTTP response was:*");
+                .WithMessage(@"Expected * to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*""byte""*expected*to be <null>*The HTTP response was:*");
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
     }
 }

--- a/test/FluentAssertions.Web.Tests/SatisfyHttpResponseMessageAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/SatisfyHttpResponseMessageAssertionsSpecs.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*{empty} to contain \"byte\"*HTTP response*");
+                .WithMessage("Expected * to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*{empty} to contain \"byte\"*HTTP response*");
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"Expected value to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*""byte""*expected*to be <null>*The HTTP response was:*");
+                .WithMessage(@"Expected * to satisfy one or more assertions, but it wasn't because we want to test the reason:*expected*""byte""*expected*to be <null>*The HTTP response was:*");
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
     }
 }

--- a/test/FluentAssertions.Web.Tests/SatisfyModelAssertionsAsyncSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/SatisfyModelAssertionsAsyncSpecs.cs
@@ -57,7 +57,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
+                .WithMessage("Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*the enum to be TestEnum.Type1*, but found TestEnum.-1**HTTP response*");
+                .WithMessage("Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*the enum to be TestEnum.Type1*, but found TestEnum.-1**HTTP response*");
         }
 
         [Fact]
@@ -202,7 +202,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
+                .WithMessage(@"Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
         }
 
         [Fact]
@@ -232,7 +232,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -310,7 +310,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
+                .WithMessage("Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
+                .WithMessage(@"Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
         }
 
         [Fact]
@@ -443,7 +443,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*the enum to be TestEnum.Type1*, but found TestEnum.-1**HTTP response*");
+                .WithMessage("Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*the enum to be TestEnum.Type1*, but found TestEnum.-1**HTTP response*");
             completed.Should().BeTrue();
         }
 
@@ -507,7 +507,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
     }

--- a/test/FluentAssertions.Web.Tests/SatisfyModelAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/SatisfyModelAssertionsSpecs.cs
@@ -68,7 +68,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
+                .WithMessage("Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
+                .WithMessage(@"Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-                .WithMessage("*Cannot verify the subject satisfies a `null` assertion.*");
+                .WithMessage("Cannot verify the subject satisfies a `null` assertion.*");
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
 
@@ -224,7 +224,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
+                .WithMessage("Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*to be empty, but found \"Value\"*HTTP response*");
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"Expected value to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
+                .WithMessage(@"Expected * to satisfy one or more model assertions, but it wasn't because we want to test the reason:*expected*Not Value*expected*to be <null>*The HTTP response was:*");
         }
 
         [Fact]
@@ -288,7 +288,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-                .WithMessage("*Cannot verify the subject satisfies a `null` assertion.*");
+                .WithMessage("Cannot verify the subject satisfies a `null` assertion.*");
         }
 
 
@@ -308,7 +308,7 @@ namespace FluentAssertions.Web.Tests
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(@"*Expected an HTTP response to assert because we want to test the failure message, but found <null>.");
+                .WithMessage(@"Expected a * to assert because we want to test the failure message, but found <null>.");
         }
         #endregion
     }


### PR DESCRIPTION
Instead of showing 'Expected response to have'
it was shown 'Expected value to have'
when the assertion was like response.Should().XXX

- inline all ExecuteAssert private methods
- change from {context:value} to {context:response}
- add CustomAssertion attribute