### PR TITLE
[WIP] Display non English characters without conversion to unicode code

### DIFF
--- a/src/FluentAssertions.Web/Internal/ContentProcessors/JsonProcessor.cs
+++ b/src/FluentAssertions.Web/Internal/ContentProcessors/JsonProcessor.cs
@@ -1,13 +1,16 @@
-﻿using System.IO;
+using System.IO;
 using System.Net.Http;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 using System.Threading.Tasks;
 
 namespace FluentAssertions.Web.Internal.ContentProcessors
 {
     internal class JsonProcessor : ProcessorBase
     {
+        private static readonly JavaScriptEncoder JavaScriptEncoder = JavaScriptEncoder.Create(UnicodeRanges.All);
         private readonly HttpContent? _httpContent;
         public JsonProcessor(HttpContent? httpContent)
         {
@@ -40,7 +43,8 @@ namespace FluentAssertions.Web.Internal.ContentProcessors
                 using var stream = new MemoryStream();
                 var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
                 {
-                    Indented = true
+                    Indented = true,
+                    Encoder = JavaScriptEncoder,
                 });
                 jsonDocument.WriteTo(writer);
                 await writer.FlushAsync();

--- a/test/FluentAssertions.Web.Tests/HttpResponseMessageFormatterSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpResponseMessageFormatterSpecs.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions.Formatting;
+using FluentAssertions.Formatting;
 using FluentAssertions.Web.Internal;
 using System;
 using System.Collections.Generic;
@@ -166,6 +166,35 @@ Content-Length:*
 The originated HTTP request was <null>.*");
         }
 
+        [Fact]
+        public void GivenResponseWithJsonContainsNonEnglishChars_ShouldNotEscaped()
+        {
+            // Arrange
+            var formattedGraph = new FormattedObjectGraph(maxLines: 100);
+            using var subject = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    @"{""message"":""папка""}",
+                    Encoding.UTF8, "application/json")
+            };
+            var sut = new HttpResponseMessageFormatter();
+
+            // Act
+            sut.Format(subject, formattedGraph, null!, null!);
+
+            // Assert
+            var formatted = formattedGraph.ToString();
+            formatted.Should().Match(@"*
+The HTTP response was:*
+HTTP/1.1 200 OK*
+Content-Type: application/json; charset=utf-8*
+Content-Length:*
+{*
+  ""message"": ""папка""
+}*
+The originated HTTP request was <null>.*");
+        }
+        
         [Fact]
         public void GivenResponseWithMinifiedJson_ShouldPrintFormattedJson()
         {


### PR DESCRIPTION
Avoid conversion non english characters to unicode codes:

Current result example:
```
{
      "message": "\u041F\u0430\u043F\u043A\u0430",
}
```
After this fix:
```
{
      "message": "Папка",
}
```
