### PR TITLE
Print the Content-Length header only if it actually exists

### DIFF
--- a/src/FluentAssertions.Web/HttpResponseMessageFormatter.cs
+++ b/src/FluentAssertions.Web/HttpResponseMessageFormatter.cs
@@ -107,7 +107,12 @@ internal class HttpResponseMessageFormatter : IValueFormatter
 
     private static void AppendContentLength(StringBuilder messageBuilder, HttpContent content)
     {
-        content.TryGetContentLength(out var length);
-        messageBuilder.AppendLine($"Content-Length: {length}");
+        if (content.Headers.TryGetValues("Content-Length", out var values))
+        {
+            foreach (var value in values)
+            {
+                messageBuilder.AppendLine($"Content-Length: {value}");
+            }
+        }
     }
 }

--- a/test/FluentAssertions.Web.Tests/HttpResponseMessageFormatterSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpResponseMessageFormatterSpecs.cs
@@ -5,7 +5,7 @@ namespace FluentAssertions.Web.Tests;
 public class HttpResponseMessageFormatterSpecs
 {
     [Fact]
-    public void GivenUnspecifiedResponse_ShouldPrintProtocolAndHaveContentLengthZero()
+    public void GivenUnspecifiedResponse_ShouldPrintProtocolAndHaveNoContentLength()
     {
         // Arrange
         var formattedGraph = new FormattedObjectGraph(maxLines: 100);
@@ -21,7 +21,6 @@ public class HttpResponseMessageFormatterSpecs
             *
             The HTTP response was:*
             HTTP/1.1 200 OK*
-            Content-Length: 0*
             The originating HTTP request was <null>.*
             """);
     }
@@ -59,7 +58,6 @@ public class HttpResponseMessageFormatterSpecs
             Date: Thu, 26 Sep 2019 22:33:34 GMT*
             Connection: close*
             Content-Type: text/html; charset=utf-8*
-            Content-Length: 0*
             The originating HTTP request was <null>.*
             """);
     }
@@ -137,7 +135,6 @@ public class HttpResponseMessageFormatterSpecs
             *The HTTP response was:*
             HTTP/1.1 200 OK*
             Content-Type: application/json; charset=utf-8*
-            Content-Length:*
             {*
               "glossary": {*
                 "title": "example glossary",*
@@ -214,7 +211,6 @@ public class HttpResponseMessageFormatterSpecs
             The HTTP response was:*
             HTTP/1.1 200 OK*
             Content-Type: application/json; charset=utf-8*
-            Content-Length:*
             {*
               "glossary": {*
                 "title": "example glossary",*
@@ -277,7 +273,6 @@ public class HttpResponseMessageFormatterSpecs
             The HTTP response was:*
             HTTP/1.1 200 OK*
             Content-Type: text/html; charset=utf-8*
-            Content-Length:*
             <html>*
             <head>*
             <title>Title of the document</title>*
@@ -324,9 +319,10 @@ public class HttpResponseMessageFormatterSpecs
         var formattedGraph = new FormattedObjectGraph(maxLines: 100);
         using var subject = new HttpResponseMessage(HttpStatusCode.OK)
         {
+            Content = new StringContent("OK") { Headers = { ContentLength = 2 } },
             RequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://localhost:5001/")
             {
-                Content = new StringContent("Some content."),
+                Content = new StringContent("Some content.") { Headers = { ContentLength = 13 } },
                 Headers = { { "Authorization", "Bearer xyz" } }
             }
         };
@@ -341,12 +337,12 @@ public class HttpResponseMessageFormatterSpecs
             """
             *The HTTP response was:*
             HTTP/1.1 200 OK*
-            Content-Length: 0*
+            Content-Length: 2*
             The originating HTTP request was:*
             POST http://localhost:5001/ HTTP*
             Authorization: Bearer xyz*
             Content-Type: text/plain; charset=utf-8*
-            Content-Length: *
+            Content-Length: 13*
             Some content.*
             """);
     }
@@ -377,12 +373,10 @@ public class HttpResponseMessageFormatterSpecs
             """
             *The HTTP response was:*
             HTTP/1.1 200 OK*
-            Content-Length: 0*
             The originating HTTP request was:*
             POST http://localhost:5001/ HTTP*
             Authorization: Bearer xyz*
             Content-Type: text/plain; charset=utf-8*
-            Content-Length: *
             Some content.*
             """);
     }
@@ -408,7 +402,7 @@ public class HttpResponseMessageFormatterSpecs
             """
             *The HTTP response was:*
             HTTP/1.1 200 OK*
-            Content-Length: 0*HTTP request*<null>*
+            *HTTP request*<null>*
             """);
     }
 
@@ -1434,7 +1428,6 @@ public class HttpResponseMessageFormatterSpecs
             *The HTTP response was:*
             HTTP/1.1 200 OK*
             Content-Type: application/json; charset=utf-8*
-            Content-Length:*
             *Content is too large to display and only a part is printed*
             {*
               "glossary": {*
@@ -1469,7 +1462,6 @@ public class HttpResponseMessageFormatterSpecs
             *The HTTP response was:*
             HTTP/1.1 200 OK*
             Content-Type: application/json; charset=utf-8*
-            Content-Length:*
             {*
                 "glossary": {*
                     "title":*


### PR DESCRIPTION
It is unsettling to see the "Content-Length" header printed in the diagnosis messages even though it is not actually present in the request and/or response headers.

Note that we can't just test whether the `ContentLength` property is null or not because the [HttpContentHeaders.ContentLength implementation][1] automatically computes a value even if the Content-Length is not present. This is why using `content.Headers.TryGetValues` is mandatory.

[1]: https://github.com/dotnet/runtime/blob/v8.0.5/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs#L41-L55