### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/FluentAssertions.Web/HttpResponseMessageFormatter.cs
+++ b/src/FluentAssertions.Web/HttpResponseMessageFormatter.cs
@@ -105,9 +105,9 @@ internal class HttpResponseMessageFormatter : IValueFormatter
         messageBuilder.AppendLine($@"HTTP/{response.Version} {(int)response.StatusCode} {response.StatusCode}");
     }
 
-    private static void AppendContentLength(StringBuilder messageBuilder, HttpContent content)
+    private static void AppendContentLength(StringBuilder messageBuilder, HttpContent? content)
     {
-        if (content.Headers.TryGetValues("Content-Length", out var values))
+        if (content != null && content.Headers.TryGetValues("Content-Length", out var values))
         {
             foreach (var value in values)
             {

--- a/test/FluentAssertions.Web.Tests/HttpResponseMessageFormatterSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpResponseMessageFormatterSpecs.cs
@@ -313,6 +313,25 @@ public class HttpResponseMessageFormatterSpecs
     }
 
     [Fact]
+    public void GivenRequestWithoutContent_ShouldNotThrowAnyException()
+    {
+        // Arrange
+        var formattedGraph = new FormattedObjectGraph(maxLines: 100);
+        using var subject = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            RequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://localhost:5001/"),
+        };
+        var sut = new HttpResponseMessageFormatter();
+
+        // Act
+        sut.Format(subject, formattedGraph, null!, null!);
+
+        // Assert
+        var formatted = formattedGraph.ToString();
+        formatted.Should().NotContain("An exception occurred");
+    }
+
+    [Fact]
     public void GivenRequest_ShouldPrintRequestDetails()
     {
         // Arrange


### PR DESCRIPTION
Pull request #122 accidentally introduced a potential NullReferenceException.

Unfortunately the .NET Standard 2.0 assemblies don't have correct nullable annotations. `System.Net.Http.HttpRequestMessage.Content` is actually nullable and should be handled as such.