### PR TITLE
fix: support 8.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="FluentAssertions" Version="[6.5.1,8.0.0)" />
+    <PackageVersion Include="FluentAssertions" Version="[6.5.1,8.0.1)" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
Fix to support FluentAssertions 8.0.1 which is just 8.0.0 with license changes? 8.0.0 release is gone from Github it seems?