### PR TITLE
References FluentAssertions.Web.Types as private asset

### DIFF
--- a/src/FluentAssertions.Web.Serializers.NewtonsoftJson/FluentAssertions.Web.Serializers.NewtonsoftJson.csproj
+++ b/src/FluentAssertions.Web.Serializers.NewtonsoftJson/FluentAssertions.Web.Serializers.NewtonsoftJson.csproj
@@ -11,7 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FluentAssertions.Web.Types\FluentAssertions.Web.Types.csproj" />
+    <ProjectReference Include="..\FluentAssertions.Web.Types\FluentAssertions.Web.Types.csproj">
+      <PrivateAssets>true</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/FluentAssertions.Web.v8/FluentAssertions.Web.v8.csproj
+++ b/src/FluentAssertions.Web.v8/FluentAssertions.Web.v8.csproj
@@ -18,7 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FluentAssertions.Web.Types\FluentAssertions.Web.Types.csproj" />
+    <ProjectReference Include="..\FluentAssertions.Web.Types\FluentAssertions.Web.Types.csproj">
+      <PrivateAssets>true</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FluentAssertions.Web/FluentAssertions.Web.csproj
+++ b/src/FluentAssertions.Web/FluentAssertions.Web.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FluentAssertions.Web.Types\FluentAssertions.Web.Types.csproj" />
+    <ProjectReference Include="..\FluentAssertions.Web.Types\FluentAssertions.Web.Types.csproj">
+      <PrivateAssets>true</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
And fix the referencing issue introduced in 1.9.0