### PR TITLE
Add HaveLocation, NotHaveLocation and Be308PermanentRedirect assertions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -292,12 +292,30 @@ NewtonsoftJsonSerializerConfig.Options.Converters.Add(new YesNoBooleanJsonConver
 | **NotHaveError()** | Asserts that a Bad Request HTTP response content does not contain an error message identifiable by an expected field name and a wildcard error text. |
 | **HaveErrorMessage()** | Asserts that a Bad Request HTTP response content contains an error message identifiable by an wildcard error text. |
 
+|  *HaveLocation* Header related assertions. | |
+| --- | --- |
+| Should().Be201Created().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 201 status code has a location header. |
+| Should().Be300Ambiguous().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 300 status code has a location header. |
+| Should().Be300MultipleChoices().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 300 status code has a location header. |
+| Should().Be301Moved().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 301 status code has a location header. |
+| Should().Be301MovedPermanently().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 301 status code has a location header. |
+| Should().Be302Found().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 302 status code has a location header. |
+| Should().Be302Redirect().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 302 status code has a location header. |
+| Should().Be303RedirectMethod().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 303 status code has a location header. |
+| Should().Be303SeeOther().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 303 status code has a location header. |
+| Should().Be304NotModified().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 304 status code has a location header. |
+| Should().Be305UseProxy().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 305 status code has a location header. |
+| Should().Be307RedirectKeepVerb().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 307 status code has a location header. |
+| Should().Be307TemporaryRedirect().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 307 status code has a location header. |
+| Should().Be308PermanentRedirect().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 308 status code has a location header. |
+| Should().Be3XXRedirection().And.**HaveLocation()**.And.BeValue() |  Asserts that an HTTP response with 308 status code has a location header. |
+
 |  *Fine grained status assertions.* | |
 | --- | --- |
 | **Should().Be1XXInformational()** |  Asserts that a HTTP response has a HTTP status code representing an informational response. |
 | **Should().Be2XXSuccessful()** | Asserts that a HTTP response has a successful HTTP status code. |
-| **Should().Be4XXClientError()** | Asserts that a HTTP response has a HTTP status code representing a client error. |
 | **Should().Be3XXRedirection()** | Asserts that a HTTP response has a HTTP status code representing a redirection response. |
+| **Should().Be4XXClientError()** | Asserts that a HTTP response has a HTTP status code representing a client error. |
 | **Should().Be5XXServerError()** | Asserts that a HTTP response has a HTTP status code representing a server error. |
 | **Should().Be100Continue()** | Asserts that a HTTP response has the HTTP status 100 Continue |
 | **Should().Be101SwitchingProtocols()** | Asserts that a HTTP response has the HTTP status 101 Switching Protocols |
@@ -321,6 +339,7 @@ NewtonsoftJsonSerializerConfig.Options.Converters.Add(new YesNoBooleanJsonConver
 | **Should().Be306Unused()** | Asserts that a HTTP response has the HTTP status 306 Unused |
 | **Should().Be307RedirectKeepVerb()** | Asserts that a HTTP response has the HTTP status 307 Redirect Keep Verb |
 | **Should().Be307TemporaryRedirect()** | Asserts that a HTTP response has the HTTP status 307 Temporary Redirect |
+| **Should().Be308PermanentRedirect()** | Asserts that a HTTP response has the HTTP status 308 Permanent Redirect |
 | **Should().Be400BadRequest()** | Asserts that a HTTP response has the HTTP status 400 BadRequest |
 | **Should().Be401Unauthorized()** | Asserts that a HTTP response has the HTTP status 401 Unauthorized |
 | **Should().Be402PaymentRequired()** | Asserts that a HTTP response has the HTTP status 402 Payment Required |

--- a/samples/Sample.Api.Shared/Controllers/CommentsController.cs
+++ b/samples/Sample.Api.Shared/Controllers/CommentsController.cs
@@ -15,15 +15,25 @@ namespace Sample.Api.Controllers
             new Comment { Author = "Johnny", Content = "Hey!", CommentId = 2 }
         };
 
-        [HttpGet("{id}")]
-        public Comment Get(int id)
+        [HttpGet("{id}", Name = "GetById")]
+        public Comment GetById(int id)
         {
             Response.Headers["x-vendor"] = "vendor";
             return new Comment { Author = "Adrian", Content = "Hey", CommentId = id };
         }
 
         [HttpPost]
-        public Comment Post([FromBody] Comment value) => value;
+        [ProducesResponseType(201)]
+        public CreatedAtRouteResult Post([FromBody] Comment value)
+        {
+            value.CommentId = 1;
+            return CreatedAtRoute("GetById",
+                new
+                {
+                    id = value.CommentId
+                },
+                value);
+        }
     }
 
     public class Comment

--- a/src/FluentAssertions.Web/HeadersAssertions.cs
+++ b/src/FluentAssertions.Web/HeadersAssertions.cs
@@ -9,7 +9,10 @@ namespace FluentAssertions.Web;
 /// </summary>
 public class HeadersAssertions : HttpResponseMessageAssertions
 {
-    private readonly string _header;
+    /// <summary>
+    /// The HTTP header name to be asserted.
+    /// </summary>
+    protected readonly string Header;
 
     /// <summary>
     /// Initialized a new instance of the <see cref="HeadersAssertions"/>
@@ -19,9 +22,9 @@ public class HeadersAssertions : HttpResponseMessageAssertions
     /// <param name="header">The HTTP header name to be asserted.</param>
 #if FAV8
     /// <param name="assertionChain">The assertion chain to build and manage assertions.</param>
-    public HeadersAssertions(HttpResponseMessage value, string header, AssertionChain assertionChain) : base(value, assertionChain) => _header = header;
+    public HeadersAssertions(HttpResponseMessage value, string header, AssertionChain assertionChain) : base(value, assertionChain) => Header = header;
 #else
-    public HeadersAssertions(HttpResponseMessage value, string header) : base(value) => _header = header;
+    public HeadersAssertions(HttpResponseMessage value, string header) : base(value) => Header = header;
 #endif
     /// <summary>
     /// Asserts that an existing HTTP header in a HTTP response contains at least a value that matches a wildcard pattern.
@@ -54,7 +57,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
             .BecauseOf(because, becauseArgs)
             .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
 
-        IEnumerable<string> headerValues = Subject!.GetHeaderValues(_header);
+        IEnumerable<string> headerValues = Subject!.GetHeaderValues(Header);
 
         var matchFound = headerValues.Any(headerValue =>
         {
@@ -72,7 +75,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
                      .ForCondition(matchFound)
                      .FailWith("Expected {context:response} to contain " +
                                "the HTTP header {0} having a value matching {1}, but there was no match{reason}. {2}",
-                         _header,
+                         Header,
                          expectedWildcardValue,
                          Subject);
 
@@ -92,7 +95,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
     [CustomAssertion]
     public AndConstraint<HeadersAssertions> BeEmpty(string because = "", params object[] becauseArgs)
     {
-        var headerValues = Subject.GetHeaderValues(_header);
+        var headerValues = Subject.GetHeaderValues(Header);
 
 #if FAV8
         CurrentAssertionChain
@@ -103,7 +106,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
                     .ForCondition(!headerValues.Any())
                     .FailWith("Expected {context:response} to contain " +
                               "the HTTP header {0} with no header values, but found the header and it has values {1} in the actual response{reason}. {2}",
-                        _header,
+                        Header,
                         headerValues,
                         Subject);
 
@@ -123,7 +126,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
     [CustomAssertion]
     public AndConstraint<HeadersAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
     {
-        var headerValues = Subject.GetHeaderValues(_header);
+        var headerValues = Subject.GetHeaderValues(Header);
 
 #if FAV8
         CurrentAssertionChain
@@ -134,7 +137,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
             .ForCondition(headerValues.Any())
             .FailWith("Expected {context:response} to contain " +
                       "the HTTP header {0} with any header values, but found the header and it has no values in the actual response{reason}. {2}",
-                _header,
+                Header,
                 headerValues,
                 Subject);
 
@@ -164,7 +167,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
             throw new ArgumentException("Cannot verify a HTTP header to be a collection of expected values against an empty collection. Use And.BeEmpty to test if the HTTP header has no values.", nameof(expectedValues));
         }
 
-        var values = Subject.GetHeaders().FirstOrDefault(c => c.Key == _header).Value;
+        var values = Subject.GetHeaders().FirstOrDefault(c => c.Key == Header).Value;
 
         string[] failures;
 
@@ -184,7 +187,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
                     .ForCondition(failures.Length == 0)
                     .FailWith("Expected {context:response} to contain " +
                               "the HTTP header {0} having values {1}, but the found values have differences{reason}. {2}",
-                        _header,
+                        Header,
                         expectedValues,
                         Subject);
 
@@ -216,12 +219,12 @@ public class HeadersAssertions : HttpResponseMessageAssertions
         Execute.Assertion
 #endif
             .BecauseOf(because, becauseArgs)
-            .ForCondition(Subject.GetHeaderValues(_header).Count() == 1)
+            .ForCondition(Subject.GetHeaderValues(Header).Count() == 1)
             .FailWith($$"""
                               Expected {context:response} to contain the {0} HTTP header and the value to be equivalent to "{{expectedValue}}", but found the header and has more or no values{reason}.{1}
-                              """, _header, Subject);
+                              """, Header, Subject);
 
-        var value = Subject.GetFirstHeaderValue(_header);
+        var value = Subject.GetFirstHeaderValue(Header);
 
         string[] failures;
 
@@ -241,7 +244,7 @@ public class HeadersAssertions : HttpResponseMessageAssertions
                     .ForCondition(failures.Length == 0)
                     .FailWith($$"""
                               Expected {context:response} to contain the {0} HTTP header and the {{ failures.FirstOrDefault()?.ReplaceFirstWithLowercase().TrimDot() }}{reason}.{1}
-                              """, _header, Subject);
+                              """, Header, Subject);
 
         return new AndConstraint<HeadersAssertions>(this);
     }
@@ -317,7 +320,7 @@ public partial class HttpResponseMessageAssertions
 #endif
             .BecauseOf(because, becauseArgs)
             .ForCondition(!IsHeaderPresent(expectedHeader))
-            .FailWith("Expected {context:response} to not to contain " +
+            .FailWith("Expected {context:response} to not contain " +
                       "the HTTP header {0}, but the header was found in the actual response{reason}.{1}",
                 expectedHeader,
                 Subject);
@@ -325,7 +328,39 @@ public partial class HttpResponseMessageAssertions
         return new AndConstraint<HttpResponseMessageAssertions>(this);
     }
 
-    private bool IsHeaderPresent(string expectedHeader)
+    /// <summary>
+    /// Asserts that an HTTP response does not have a Location header.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public AndConstraint<HttpResponseMessageAssertions> NotHaveLocation(string because = "", params object[] becauseArgs)
+    {
+#if FAV8
+        CurrentAssertionChain
+#else
+        Execute.Assertion
+#endif
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(!IsHeaderPresent("Location"))
+            .FailWith("Expected {context:response} to not contain " +
+                      "the Location HTTP header, but the header was found in the actual response{reason}.{0}",
+                Subject);
+
+        return new AndConstraint<HttpResponseMessageAssertions>(this);
+    }
+
+    /// <summary>
+    /// Checks if the expected header is present in the HTTP response headers.
+    /// </summary>
+    /// <param name="expectedHeader"></param>
+    /// <returns></returns>
+    protected bool IsHeaderPresent(string expectedHeader)
         => Subject
             .GetHeaders()
             .Any(c => string.Equals(c.Key, expectedHeader, StringComparison.OrdinalIgnoreCase));

--- a/src/FluentAssertions.Web/HeadersAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HeadersAssertionsExtensions.cs
@@ -52,5 +52,23 @@ public static class HeadersAssertionsExtensions
         string expectedHeader,
         string because = "", params object[] becauseArgs)
         => new HttpResponseMessageAssertions(parent.Subject).NotHaveHeader(expectedHeader, because, becauseArgs);
+
+    /// <summary>
+    /// Asserts that an HTTP response does not have a Location header.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public static AndConstraint<HttpResponseMessageAssertions> NotHaveLocation(
+#pragma warning disable 1573
+        this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
+#pragma warning restore 1573
+        string because = "", params object[] becauseArgs)
+        => new HttpResponseMessageAssertions(parent.Subject).NotHaveLocation(because, becauseArgs);
 }
 #endif

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertions.cs
@@ -393,7 +393,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be201Created(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be201Created(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -413,7 +413,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Created == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.Created, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -427,7 +431,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be202Accepted(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be202Accepted(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -447,7 +451,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Accepted == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.Accepted, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -495,7 +503,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be204NoContent(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be204NoContent(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -515,7 +523,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.NoContent == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.NoContent, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -597,7 +609,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be300MultipleChoices(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be300MultipleChoices(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -617,7 +629,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.MultipleChoices == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , "HttpStatusCode.MultipleChoices {value: 300}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -631,7 +647,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be300Ambiguous(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be300Ambiguous(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -651,7 +667,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Ambiguous == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , $"{nameof(HttpStatusCode)}.{nameof(HttpStatusCode.Ambiguous)}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -665,7 +685,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be301MovedPermanently(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be301MovedPermanently(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -685,7 +705,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.MovedPermanently == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , "HttpStatusCode.MovedPermanently {value: 301}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -699,7 +723,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be301Moved(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be301Moved(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -719,7 +743,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Moved == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.Moved, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -733,7 +761,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be302Found(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be302Found(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -753,7 +781,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Found == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , "HttpStatusCode.Found {value: 302}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -767,7 +799,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be302Redirect(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be302Redirect(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -787,7 +819,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Redirect == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , $"{nameof(HttpStatusCode)}.{nameof(HttpStatusCode.Redirect)}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -801,7 +837,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be303SeeOther(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be303SeeOther(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -821,7 +857,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.SeeOther == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , "HttpStatusCode.SeeOther {value: 303}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -835,7 +875,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be303RedirectMethod(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be303RedirectMethod(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -855,7 +895,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.RedirectMethod == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , $"{nameof(HttpStatusCode)}.{nameof(HttpStatusCode.RedirectMethod)}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -903,7 +947,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be305UseProxy(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be305UseProxy(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -923,7 +967,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.UseProxy == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.UseProxy, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -971,7 +1019,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be307TemporaryRedirect(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be307TemporaryRedirect(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -991,7 +1039,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.TemporaryRedirect == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , $"{nameof(HttpStatusCode)}.{nameof(HttpStatusCode.TemporaryRedirect)}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -1005,7 +1057,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be307RedirectKeepVerb(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be307RedirectKeepVerb(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -1025,7 +1077,49 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.RedirectKeepVerb == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , "HttpStatusCode.RedirectKeepVerb {value: 307}", Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
+    }
+
+    /// <summary>
+    /// Asserts that a HTTP response has the HTTP status 308 Permanent Redirect
+    /// </summary>        
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public AndConstraint<LocationAssertions> Be308PermanentRedirect(string because = "", params object[] becauseArgs)
+    {
+#if FAV8
+        CurrentAssertionChain
+#else
+        Execute.Assertion
+#endif
+            .ForCondition(Subject is not null)
+            .BecauseOf(because, becauseArgs)
+            .FailWith("Expected a {context:response} to assert{reason}, but found <null>.");
+
+#if FAV8
+        CurrentAssertionChain
+#else
+        Execute.Assertion
+#endif
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(308 == (int)Subject!.StatusCode)
+            .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
+                , "HttpStatusCode.PermanentRedirect {value: 308}", Subject!.StatusCode, Subject);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -1349,7 +1443,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be409Conflict(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be409Conflict(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -1369,7 +1463,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Conflict == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.Conflict, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>
@@ -1383,7 +1481,7 @@ public partial class HttpResponseMessageAssertions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public AndConstraint<HttpResponseMessageAssertions> Be410Gone(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be410Gone(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -1403,7 +1501,11 @@ public partial class HttpResponseMessageAssertions
             .ForCondition(HttpStatusCode.Gone == Subject!.StatusCode)
             .FailWith("Expected {context:response} to be {0}{reason}, but found {1}.{2}"
                 , HttpStatusCode.Gone, Subject!.StatusCode, Subject);
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
 
     /// <summary>

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertions.cs
@@ -98,7 +98,7 @@ public partial class HttpResponseMessageAssertions
     /// </param>
     [CustomAssertion]
     // ReSharper disable once InconsistentNaming
-    public AndConstraint<HttpResponseMessageAssertions> Be3XXRedirection(string because = "", params object[] becauseArgs)
+    public AndConstraint<LocationAssertions> Be3XXRedirection(string because = "", params object[] becauseArgs)
     {
 #if FAV8
         CurrentAssertionChain
@@ -119,7 +119,11 @@ public partial class HttpResponseMessageAssertions
             .FailWith("Expected {context:response} to have a HTTP status code representing a redirection, but it was {0}{reason}.{1}",
                 Subject!.StatusCode, Subject);
 
-        return new AndConstraint<HttpResponseMessageAssertions>(this);
+#if FAV8
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject, CurrentAssertionChain));
+#else
+        return new AndConstraint<LocationAssertions>(new LocationAssertions(Subject));
+#endif
     }
     #endregion
 

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
@@ -543,24 +543,6 @@ public static class HttpStatusCodeAssertionsExtensions
         => new LocationAssertions(parent.Subject).Be307TemporaryRedirect(because, becauseArgs);
 
     /// <summary>
-    /// Asserts that a HTTP response has the HTTP status 308 Permanent Redirect
-    /// </summary>        
-    /// <param name="because">
-    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-    /// </param>
-    /// <param name="becauseArgs">
-    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
-    /// </param>
-    [CustomAssertion]
-    public static AndConstraint<LocationAssertions> Be308PermanentRedirect(
-#pragma warning disable 1573
-        this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
-#pragma warning restore 1573,
-        string because = "", params object[] becauseArgs)
-        => new LocationAssertions(parent.Subject).Be308PermanentRedirect(because, becauseArgs);
-
-    /// <summary>
     /// Asserts that a HTTP response has the HTTP status 307 Redirect Keep Verb
     /// </summary>        
     /// <param name="because">
@@ -577,6 +559,24 @@ public static class HttpStatusCodeAssertionsExtensions
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
         => new LocationAssertions(parent.Subject).Be307RedirectKeepVerb(because, becauseArgs);
+
+    /// <summary>
+    /// Asserts that a HTTP response has the HTTP status 308 Permanent Redirect
+    /// </summary>        
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public static AndConstraint<LocationAssertions> Be308PermanentRedirect(
+#pragma warning disable 1573
+        this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
+#pragma warning restore 1573,
+        string because = "", params object[] becauseArgs)
+        => new LocationAssertions(parent.Subject).Be308PermanentRedirect(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 400 BadRequest

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
@@ -499,12 +499,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be305UseProxy(
+    public static AndConstraint<LocationAssertions> Be305UseProxy(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be305UseProxy(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be305UseProxy(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 306 Unused

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
@@ -229,12 +229,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be201Created(
+    public static AndConstraint<LocationAssertions> Be201Created(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be201Created(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be201Created(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 202 Accepted
@@ -247,12 +247,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be202Accepted(
+    public static AndConstraint<LocationAssertions> Be202Accepted(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be202Accepted(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be202Accepted(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 203 Non Authoritative Information
@@ -283,12 +283,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be204NoContent(
+    public static AndConstraint<LocationAssertions> Be204NoContent(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be204NoContent(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be204NoContent(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 205 Reset Content
@@ -337,12 +337,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be300MultipleChoices(
+    public static AndConstraint<LocationAssertions> Be300MultipleChoices(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be300MultipleChoices(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be300MultipleChoices(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 300 Ambiguous
@@ -355,12 +355,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be300Ambiguous(
+    public static AndConstraint<LocationAssertions> Be300Ambiguous(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be300Ambiguous(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be300Ambiguous(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 301 Moved Permanently
@@ -373,12 +373,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be301MovedPermanently(
+    public static AndConstraint<LocationAssertions> Be301MovedPermanently(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be301MovedPermanently(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be301MovedPermanently(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 301 Moved
@@ -391,12 +391,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be301Moved(
+    public static AndConstraint<LocationAssertions> Be301Moved(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be301Moved(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be301Moved(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 302 Found
@@ -409,12 +409,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be302Found(
+    public static AndConstraint<LocationAssertions> Be302Found(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be302Found(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be302Found(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 302 Redirect
@@ -427,12 +427,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be302Redirect(
+    public static AndConstraint<LocationAssertions> Be302Redirect(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be302Redirect(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be302Redirect(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 303 See Other
@@ -445,12 +445,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be303SeeOther(
+    public static AndConstraint<LocationAssertions> Be303SeeOther(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be303SeeOther(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be303SeeOther(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 303 Redirect Method
@@ -463,12 +463,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be303RedirectMethod(
+    public static AndConstraint<LocationAssertions> Be303RedirectMethod(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be303RedirectMethod(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be303RedirectMethod(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 304 Not Modified
@@ -535,12 +535,30 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be307TemporaryRedirect(
+    public static AndConstraint<LocationAssertions> Be307TemporaryRedirect(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be307TemporaryRedirect(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be307TemporaryRedirect(because, becauseArgs);
+
+    /// <summary>
+    /// Asserts that a HTTP response has the HTTP status 308 Permanent Redirect
+    /// </summary>        
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public static AndConstraint<LocationAssertions> Be308PermanentRedirect(
+#pragma warning disable 1573
+        this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
+#pragma warning restore 1573,
+        string because = "", params object[] becauseArgs)
+        => new LocationAssertions(parent.Subject).Be308PermanentRedirect(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 307 Redirect Keep Verb
@@ -553,12 +571,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be307RedirectKeepVerb(
+    public static AndConstraint<LocationAssertions> Be307RedirectKeepVerb(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be307RedirectKeepVerb(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be307RedirectKeepVerb(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 400 BadRequest
@@ -733,12 +751,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be409Conflict(
+    public static AndConstraint<LocationAssertions> Be409Conflict(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be409Conflict(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be409Conflict(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 410 Gone
@@ -751,12 +769,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// Zero or more objects to format using the placeholders in <see paramref="because" />.
     /// </param>
     [CustomAssertion]
-    public static AndConstraint<HttpResponseMessageAssertions> Be410Gone(
+    public static AndConstraint<LocationAssertions> Be410Gone(
 #pragma warning disable 1573
         this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573,
         string because = "", params object[] becauseArgs)
-        => new HttpResponseMessageAssertions(parent.Subject).Be410Gone(because, becauseArgs);
+        => new LocationAssertions(parent.Subject).Be410Gone(because, becauseArgs);
 
     /// <summary>
     /// Asserts that a HTTP response has the HTTP status 411 Length Required

--- a/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/HttpStatusCodeAssertionsExtensions.cs
@@ -65,12 +65,12 @@ public static class HttpStatusCodeAssertionsExtensions
     /// </param>
     [CustomAssertion]
     // ReSharper disable once InconsistentNaming
-    public static AndConstraint<HttpResponseMessageAssertions> Be3XXRedirection(
+    public static AndConstraint<LocationAssertions> Be3XXRedirection(
 #pragma warning disable 1573
     this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
 #pragma warning restore 1573
     string because = "", params object[] becauseArgs)
-    => new HttpResponseMessageAssertions(parent.Subject).Be3XXRedirection(because, becauseArgs);
+    => new LocationAssertions(parent.Subject).Be3XXRedirection(because, becauseArgs);
     #endregion
 
     #region Be4XXClientError

--- a/src/FluentAssertions.Web/LocationAssertions.cs
+++ b/src/FluentAssertions.Web/LocationAssertions.cs
@@ -1,0 +1,58 @@
+﻿#if AAV
+namespace AwesomeAssertions.Web;
+#else
+namespace FluentAssertions.Web;
+#endif
+
+/// <summary>
+/// Contains a number of methods to assert that an <see cref="HttpResponseMessage"/> is in the expected state related to HTTP headers.
+/// </summary>
+public class LocationAssertions : HeadersAssertions
+{
+    /// <summary>
+    /// Initialized a new instance of the <see cref="LocationAssertions"/>
+    /// class.
+    /// </summary>
+    /// <param name="value">The subject value to be asserted.</param>
+#if FAV8
+    /// <param name="assertionChain">The assertion chain to build and manage assertions.</param>
+    public LocationAssertions(HttpResponseMessage value, AssertionChain assertionChain) : base(value, "Location", assertionChain) { }
+#else
+    public LocationAssertions(HttpResponseMessage value) : base(value, "Location") { }
+#endif
+
+    /// <summary>
+    /// Asserts that an HTTP response has a Location header.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public AndConstraint<HeadersAssertions> HaveLocation(string because = "", params object[] becauseArgs)
+    {
+#if FAV8
+        CurrentAssertionChain
+#else
+        Execute.Assertion
+#endif
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(IsHeaderPresent(Header))
+            .FailWith("Expected {context:response} to contain " +
+                      "the Location HTTP header, but no such header was found in the actual response{reason}.{0}",
+                Subject);
+#if FAV8
+        return new AndConstraint<HeadersAssertions>(new HeadersAssertions(Subject, Header, CurrentAssertionChain));
+#else
+        return new AndConstraint<HeadersAssertions>(new HeadersAssertions(Subject, Header));
+#endif
+    }
+
+    /// <summary>
+    /// Assertion identifier for the <see cref="LocationAssertions"/> class.
+    /// </summary>
+    protected override string Identifier => "Header.Location";
+}

--- a/src/FluentAssertions.Web/LocationAssertionsExtensions.cs
+++ b/src/FluentAssertions.Web/LocationAssertionsExtensions.cs
@@ -1,0 +1,30 @@
+﻿#if !FAV8
+
+namespace FluentAssertions;
+
+
+/// <summary>
+/// Contains extension methods for custom assertions in unit tests related to <see cref="LocationAssertions"/>.
+/// </summary>
+[DebuggerNonUserCode]
+public static class LocationAssertionsExtensions
+{
+    /// <summary>
+    /// Asserts that an HTTP response has a Location header.
+    /// </summary>
+    /// <param name="because">
+    /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+    /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+    /// </param>
+    /// <param name="becauseArgs">
+    /// Zero or more objects to format using the placeholders in <see paramref="because" />.
+    /// </param>
+    [CustomAssertion]
+    public static AndConstraint<HeadersAssertions> HaveLocation(
+#pragma warning disable 1573
+        this Primitives.HttpResponseMessageAssertions<Primitives.HttpResponseMessageAssertions> parent,
+#pragma warning restore 1573
+        string because = "", params object[] becauseArgs)
+    => new LocationAssertions(parent.Subject).HaveLocation(because, becauseArgs);
+}
+#endif

--- a/test/FluentAssertions.Web.Tests/HeadersAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HeadersAssertionsSpecs.cs
@@ -153,7 +153,7 @@ public class HeadersAssertionsSpecs
 
         // Assert
         act.Should().Throw<XunitException>()
-            .WithMessage("*to not to contain the HTTP header*that-header*but the header was found*reason*");
+            .WithMessage("*to not contain the HTTP header*that-header*but the header was found*reason*");
     }
 
     [Fact]

--- a/test/FluentAssertions.Web.Tests/HttpStatusCodeAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpStatusCodeAssertionsSpecs.cs
@@ -1385,7 +1385,7 @@ public class HttpStatusCodeAssertionsSpecs
     public void When_asserting_other_than_308_Permanent_Redirect_response_to_be_308PermanentRedirect_it_should_throw_with_descriptive_message()
     {
         // Arrange
-        using var subject = new HttpResponseMessage((HttpStatusCode)308);
+        using var subject = new HttpResponseMessage(HttpStatusCode.OK);
 
         // Act
         Action act = () =>

--- a/test/FluentAssertions.Web.Tests/HttpStatusCodeAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/HttpStatusCodeAssertionsSpecs.cs
@@ -1366,6 +1366,52 @@ public class HttpStatusCodeAssertionsSpecs
     }
     #endregion 
 
+    #region 308 Permanent Redirect
+    [Fact]
+    public void When_asserting_308_Permanent_Redirect_response_to_be_308PermanentRedirect_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage((HttpStatusCode)308);
+
+        // Act
+        Action act = () =>
+            subject.Should().Be308PermanentRedirect();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_other_than_308_Permanent_Redirect_response_to_be_308PermanentRedirect_it_should_throw_with_descriptive_message()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage((HttpStatusCode)308);
+
+        // Act
+        Action act = () =>
+            subject.Should().Be308PermanentRedirect("because we want to test the failure {0}", "message");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("*HttpStatusCode.PermanentRedirect*because we want to test the failure message, but found HttpStatusCode.OK {value: 200}*");
+    }
+
+    [Fact]
+    public void When_asserting_null_HttpResponse_to_be_308PermanentRedirect_it_should_throw_with_descriptive_message()
+    {
+        // Arrange
+        HttpResponseMessage? subject = null;
+
+        // Act
+        Action act = () =>
+            subject.Should().Be308PermanentRedirect("because we want to test the failure {0}", "message");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected a * to assert because we want to test the failure message, but found <null>.");
+    }
+    #endregion 
+
     #region 400 BadRequest
     [Fact]
     public void When_asserting_400_BadRequest_response_to_be_400_BadRequest_it_should_succeed()

--- a/test/FluentAssertions.Web.Tests/LocationAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/LocationAssertionsSpecs.cs
@@ -205,10 +205,10 @@ public class LocationAssertionsSpecs
     }
 
     [Fact]
-    public void When_asserting_308_redirect_keep_verb_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    public void When_asserting_308_permanent_redirect_response_with_location_header_to_have_the_location_header_it_should_succeed()
     {
         // Arrange
-        using var subject = new HttpResponseMessage(HttpStatusCode.RedirectKeepVerb)
+        using var subject = new HttpResponseMessage(HttpStatusCode.PermanentRedirect)
         {
             Headers =
             {

--- a/test/FluentAssertions.Web.Tests/LocationAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/LocationAssertionsSpecs.cs
@@ -1,0 +1,277 @@
+﻿#if AAV
+namespace AwesomeAssertions.Web.Tests;
+#else
+namespace FluentAssertions.Web.Tests;
+#endif
+
+public class LocationAssertionsSpecs
+{
+    #region HaveLocation
+    [Fact]
+    public void When_asserting_201_created_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be201Created().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData((string?)null)]
+    public void When_asserting_201_created_response_with_location_header_and_no_header_value_to_have_the_location_header_it_should_succeed(string? locationValue)
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Created);
+        subject.Headers.TryAddWithoutValidation("Location", locationValue);
+
+        // Act
+        Action act = () =>
+            subject.Should().Be201Created().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_300_ambiguous_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Ambiguous)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be300Ambiguous().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_301_moved_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Moved)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be301Moved().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_301_moved_permanently_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.MovedPermanently)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be301MovedPermanently().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_302_found_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Found)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be302Found().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_303_see_other_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.SeeOther)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be303SeeOther().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_305_use_proxy_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.UseProxy)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be305UseProxy().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_307_temporary_redirect_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be307TemporaryRedirect().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_307_redirect_keep_verb_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.RedirectKeepVerb)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be307RedirectKeepVerb().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_308_redirect_keep_verb_response_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.RedirectKeepVerb)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be308PermanentRedirect().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void When_asserting_201_created_response_without_location_header_to_have_the_location_header_it_should_throw_with_descriptive_message()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Created);
+
+        // Act
+        Action act = () =>
+            subject.Should().Be201Created().And.HaveLocation("we want to test the {0}", "reason");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected subject to contain the Location HTTP header, but no such header was found in the actual response*reason*.");
+    }
+    #endregion
+
+    #region NotHaveLocation
+    [Fact]
+    public void When_asserting_a_response_without_a_location_header_not_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.OK);
+
+        // Act
+        Action act = () =>
+            subject.Should().NotHaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData((string?)null)]
+    public void When_asserting_a_response_with_location_header_and_no_header_value_to_not_have_the_location_header_it_should_throw_with_descriptive_message(string? locationValue)
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.Created);
+        subject.Headers.TryAddWithoutValidation("Location", locationValue);
+
+        // Act
+        Action act = () =>
+            subject.Should().Be201Created().And.NotHaveLocation("we want to test the {0}", "reason");
+
+        // Assert
+        act.Should().Throw<XunitException>()
+            .WithMessage("Expected subject to not contain the Location HTTP header, but the header was found in the actual response*reason*.");
+    }
+
+    #endregion
+}

--- a/test/FluentAssertions.Web.Tests/LocationAssertionsSpecs.cs
+++ b/test/FluentAssertions.Web.Tests/LocationAssertionsSpecs.cs
@@ -225,6 +225,26 @@ public class LocationAssertionsSpecs
     }
 
     [Fact]
+    public void When_asserting_3xx_redirection_with_location_header_to_have_the_location_header_it_should_succeed()
+    {
+        // Arrange
+        using var subject = new HttpResponseMessage(HttpStatusCode.PermanentRedirect)
+        {
+            Headers =
+            {
+                { "Location", "1.html" }
+            }
+        };
+
+        // Act
+        Action act = () =>
+            subject.Should().Be3XXRedirection().And.HaveLocation();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void When_asserting_201_created_response_without_location_header_to_have_the_location_header_it_should_throw_with_descriptive_message()
     {
         // Arrange

--- a/test/Sample.Api.Tests/CommentsControllerTests.cs
+++ b/test/Sample.Api.Tests/CommentsControllerTests.cs
@@ -125,7 +125,7 @@ namespace Sample.Api.Tests
         }
 
         [Fact]
-        public async Task Post_ReturnsOk()
+        public async Task Post_ReturnsCreated()
         {
             // Arrange
             var client = _factory.CreateClient();
@@ -137,11 +137,11 @@ namespace Sample.Api.Tests
                     }", Encoding.UTF8, "application/json"));
 
             // Assert
-            response.Should().Be200Ok();
+            response.Should().Be201Created().And.HaveLocation().And.Match("*/api/Comments/1");
         }
 
         [Fact]
-        public async Task Post_ReturnsOkAndWithContent()
+        public async Task Post_ReturnsCreatedAndWithContent()
         {
             // Arrange
             var client = _factory.CreateClient();
@@ -153,7 +153,9 @@ namespace Sample.Api.Tests
                     }", Encoding.UTF8, "application/json"));
 
             // Assert
-            response.Should().Be200Ok().And.BeAs(new
+            response.Should().Be201Created()
+                .And.HaveLocation().And.BeValue("http://localhost/api/Comments/1")
+                .And.BeAs(new
             {
                 Author = "John",
                 Content = "Hey, you..."

--- a/test/Sample.Api.Tests/CommentsControllerTests.cs
+++ b/test/Sample.Api.Tests/CommentsControllerTests.cs
@@ -231,5 +231,21 @@ namespace Sample.Api.Tests
             response.Should().Be400BadRequest()
                 .And.OnlyHaveError("Author", "The Author field is required.");
         }
+
+        [Fact]
+        public async Task Post_WithNoAuthorButWithContent_Returns_Bad_Request_With_No_Location()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.PostAsync("/api/comments", new StringContent(/*lang=json,strict*/ @"{
+                                          ""content"": ""Hey, you...""
+                                        }", Encoding.UTF8, "application/json"));
+
+            // Assert
+            response.Should().Be400BadRequest()
+                .And.NotHaveLocation("Bad Request responses are not designed to have Location headers.");
+        }
     }
 }


### PR DESCRIPTION
*HaveLocation* assertions

```csharp
 [Fact]
 public async Task Post_ReturnsCreatedAndWithContent()
 {
     // Arrange
     var client = _factory.CreateClient();

     // Act
     var response = await client.PostAsync("/api/comments", new StringContent(/*lang=json,strict*/ @"{
               ""author"": ""John"",
               ""content"": ""Hey, you...""
             }", Encoding.UTF8, "application/json"));

     // Assert
     response.Should().Be201Created()
         .And.HaveLocation().And.BeValue("http://localhost/api/Comments/1")
         .And.BeAs(new
     {
         Author = "John",
         Content = "Hey, you..."
     });
 }
 ```
 *NotHaveLocation* assertions
```csharp
        [Fact]
        public async Task Post_WithNoAuthorButWithContent_Returns_Bad_Request_With_No_Location()
        {
            // Arrange
            var client = _factory.CreateClient();

            // Act
            var response = await client.PostAsync("/api/comments", new StringContent(/*lang=json,strict*/ @"{
                                          ""content"": ""Hey, you...""
                                        }", Encoding.UTF8, "application/json"));

            // Assert
            response.Should().Be400BadRequest()
                .And.NotHaveLocation("Bad Request responses are not designed to have Location headers.");
        }
 ```
 Addresses issue #58 
