### PR TITLE
Hide WebApi.Client compile assets from package consumers

### DIFF
--- a/src/AwesomeAssertions.Web/AwesomeAssertions.Web.csproj
+++ b/src/AwesomeAssertions.Web/AwesomeAssertions.Web.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions"/>
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FluentAssertions.Web.v8/FluentAssertions.Web.v8.csproj
+++ b/src/FluentAssertions.Web.v8/FluentAssertions.Web.v8.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" VersionOverride="8.0.0" />
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FluentAssertions.Web/FluentAssertions.Web.csproj
+++ b/src/FluentAssertions.Web/FluentAssertions.Web.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HttpMessageFormatter/HttpMessageFormatter.csproj
+++ b/src/HttpMessageFormatter/HttpMessageFormatter.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" PrivateAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- keep `Microsoft.AspNet.WebApi.Client` available to `HttpMessageFormatter` while marking its compile assets private
- remove redundant direct WebApi.Client references from the assertion packages
- prevent `System.Net.Http.Formatting.dll` from entering downstream compiler inputs

## Why

AwesomeAssertions.Web 2.0.0 transitively exposes `System.Net.Http.Formatting.dll`. That assembly defines `PostAsJsonAsync` and `PutAsJsonAsync` overloads that collide with the modern `System.Net.Http.Json` cancellation-token overloads, causing CS0121 in consumers.

`System.Net.Http.Formatting` belongs to the legacy ASP.NET Web API 2 stack rather than the modern `System.Net.Http.Json` model. The [.NET design](https://github.com/dotnet/designs/blob/main/accepted/2020/json-http-extensions/json-http-extensions.md) for the latter deliberately introduced a separate assembly to avoid mixing WebApi.Client's JSON.NET integration with System.Text.Json. Regardless of the legacy package's support status, exposing both extension sets to downstream compiler inputs creates the ambiguity addressed here.

`HttpMessageFormatter` still needs WebApi.Client for `ReadAsMultipartAsync` and `MultipartMemoryStreamProvider`. `PrivateAssets="compile"` preserves the dependency for this project's compilation and keeps its runtime assets in the package graph, while excluding only downstream compile assets. The formatter uses these APIs on netstandard2.0, net8.0, and net10.0, so this applies unconditionally rather than by target framework.

Consumers that intentionally use WebApi.Client APIs can continue to reference `Microsoft.AspNet.WebApi.Client` directly. NuGet's direct-dependency precedence then restores `System.Net.Http.Formatting.dll` to their compiler inputs.

## Existing downstream workaround

Downstream packages currently need a `buildTransitive` MSBuild target that runs after `ResolvePackageAssets` and removes `System.Net.Http.Formatting` from `ResolvedCompileFileDefinitions` while leaving runtime assets intact:

```xml
<Target Name="RemoveSystemNetHttpFormattingCompileAsset"
        AfterTargets="ResolvePackageAssets">
  <ItemGroup>
    <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)"
                                    Condition="'%(Filename)%(Extension)' == 'System.Net.Http.Formatting.dll'" />
  </ItemGroup>
</Target>
```

This works, but it is a brittle workaround tied to NuGet/MSBuild implementation details. Correcting the dependency asset metadata upstream lets consumers remove that target while preserving the required runtime assembly.

## Validation

- `dotnet test FluentAssertions.Web.sln --configuration Release`: 1,431 passed, 9 skipped, 0 failed; the existing `HttpMessageFormatter.Tests` suite passed 17/17
- packed `AwesomeAssertions.Web`, `HttpMessageFormatter`, `FluentAssertions.Web`, and `FluentAssertions.Web.v8` without changing source versions
- inspected generated nuspec dependency groups and verified WebApi.Client remains a runtime dependency while its compile assets are excluded downstream
- built clean netstandard2.0, net48, net8.0, net9.0, and net10.0 consumers using the exact affected `PostAsJsonAsync(url, value, cancellationToken)` and `PutAsJsonAsync(url, value, cancellationToken)` calls
- verified each consumer's `project.assets.json` retains `System.Net.Http.Formatting.dll` as a runtime asset while excluding it from compiler inputs; netstandard2.0/net8.0/net9.0/net10.0 select the netstandard2.0 runtime asset and net48 selects the net45 runtime asset
- exercised multipart `StreamContent` formatting for net8.0, net9.0, and net10.0 target builds, confirming WebApi.Client runtime behavior remains intact
- built separate netstandard2.0 and net48 consumers with an explicit direct `Microsoft.AspNet.WebApi.Client` reference and use of `MultipartMemoryStreamProvider`; both compiled successfully and selected `System.Net.Http.Formatting.dll` for compile and runtime

The solution build retains its pre-existing package-constraint, analyzer-deprecation, and nullable warnings.

