### PR TITLE
Replace legacy WebApi.Client multipart parsing with modern WebUtilities

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageVersion Include="FluentAssertions" Version="[6.5.1,8.0.0)" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="2.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />

--- a/src/HttpMessageFormatter/HttpMessageFormatter.csproj
+++ b/src/HttpMessageFormatter/HttpMessageFormatter.csproj
@@ -13,14 +13,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
+  </ItemGroup>
+
   <!-- 3. Conditional dependencies to prevent ecosystem bloat -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http.Json" />
     <PackageReference Include="System.Text.Encodings.Web" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" PrivateAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HttpMessageFormatter/Internal/ContentProcessors/HttpContentMultipartExtensions.cs
+++ b/src/HttpMessageFormatter/Internal/ContentProcessors/HttpContentMultipartExtensions.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace HttpMessageFormatter.Internal.ContentProcessors;
+
+internal static class HttpContentMultipartExtensions
+{
+    public static async Task<IReadOnlyCollection<HttpContent>> ReadAsMultipartExtensionAsync(this HttpContent content)
+    {
+        var mediaType = content.Headers.ContentType;
+        if (mediaType == null) throw new ArgumentException("Missing Content-Type header.");
+
+        string? boundary = null;
+        foreach (var parameter in mediaType.Parameters)
+        {
+            if (parameter.Name.Equals("boundary", StringComparison.OrdinalIgnoreCase))
+            {
+                boundary = parameter.Value?.Trim('"');
+                break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(boundary)) throw new InvalidDataException("Missing multipart boundary.");
+
+        var parts = new List<HttpContent>();
+
+        using var stream = await content.ReadAsStreamAsync();
+        var reader = new MultipartReader(boundary, stream);
+
+        while (await reader.ReadNextSectionAsync() is { } section)
+        {
+            var memoryStream = new MemoryStream();
+            await section.Body.CopyToAsync(memoryStream);
+            memoryStream.Position = 0;
+
+            var partContent = new StreamContent(memoryStream);
+
+            foreach (var header in section.Headers)
+            {
+                partContent.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
+            }
+
+            parts.Add(partContent);
+        }
+
+        return parts;
+    }
+}

--- a/src/HttpMessageFormatter/Internal/ContentProcessors/MultipartProcessor.cs
+++ b/src/HttpMessageFormatter/Internal/ContentProcessors/MultipartProcessor.cs
@@ -16,17 +16,21 @@ internal class MultipartProcessor : ProcessorBase
         {
             multipartContent = dataContent;
         }
-        else
+        else if (_httpContent is MultipartContent generalMultipartContent)
         {
-            if (_httpContent is StreamContent streamContent)
+            multipartContent = generalMultipartContent;
+        }
+        else if (_httpContent is StreamContent streamContent)
+        {
+            var stream = await streamContent.ReadAsStreamAsync();
+            if (stream.CanSeek)
             {
-                var stream = await streamContent.ReadAsStreamAsync();
-                if (stream.CanSeek)
-                {
-                    stream.Seek(0, SeekOrigin.Begin);
-                }
+                stream.Seek(0, SeekOrigin.Begin);
+            }
 
-                multipartContent = (await _httpContent.ReadAsMultipartAsync(new MultipartMemoryStreamProvider())).Contents;
+            if (_httpContent.Headers.ContentType?.MediaType?.StartsWith("multipart/", System.StringComparison.OrdinalIgnoreCase) == true)
+            {
+                multipartContent = await _httpContent.ReadAsMultipartExtensionAsync();
             }
         }
 
@@ -37,14 +41,27 @@ internal class MultipartProcessor : ProcessorBase
 
         var boundary = GetBoundary();
 
-        foreach (var content in multipartContent)
+        try
         {
-            contentBuilder.AppendLine();
-            contentBuilder.AppendLine(boundary);
 
-            Appender.AppendHeaders(contentBuilder, content.Headers);
+            // ReSharper disable once PossibleMultipleEnumeration
+            foreach (var content in multipartContent)
+            {
+                contentBuilder.AppendLine();
+                contentBuilder.AppendLine(boundary);
 
-            await Appender.AppendContent(contentBuilder, content, true);
+                Appender.AppendHeaders(contentBuilder, content.Headers);
+
+                await Appender.AppendContent(contentBuilder, content, true);
+            }
+        }
+        finally
+        {
+            // ReSharper disable once PossibleMultipleEnumeration
+            foreach (var content in multipartContent)
+            {
+                content.Dispose();
+            }
         }
 
         contentBuilder.AppendLine();
@@ -66,12 +83,8 @@ internal class MultipartProcessor : ProcessorBase
     private string? GetBoundary()
     {
         var contentType = _httpContent?.Headers?.ContentType;
-        if (contentType?.Parameters == null)
-        {
-            return null;
-        }
 
-        var boundaryParameter = contentType.Parameters.FirstOrDefault(p => p.Name.Equals("boundary", StringComparison.OrdinalIgnoreCase));
+        var boundaryParameter = contentType?.Parameters?.FirstOrDefault(p => p.Name.Equals("boundary", StringComparison.OrdinalIgnoreCase));
         return boundaryParameter != null ? $"--{boundaryParameter.Value}" : null;
     }
 }


### PR DESCRIPTION
Removes the legacy `Microsoft.AspNet.WebApi.Client` package dependency and its high-allocation `MultipartMemoryStreamProvider` execution path.

- Replaces `ReadAsMultipartAsync` with an efficient custom extension utilizing `MultipartReader` from `Microsoft.AspNetCore.WebUtilities`.
- Safely isolates and eagerly buffers individual multipart section data into memory streams to prevent `Unexpected end of Stream` exceptions during asynchronous iterations.
- Preserves downstream `HttpContent` polymorphic formatting and streaming architectures across all multi-targeted platforms (`netstandard2.0`, `net8.0`, and `net10.0`).
- Keeps the modern .NET targets clear of unneeded dependencies by cleanly scoping legacy package assets to the .NET Standard target.

**Before**
```
λ dotnet list src/FluentAssertions.Web/FluentAssertions.Web.csproj package --include-transitive

Build succeeded in 3.6s
Restore complete (0.6s)

Build succeeded in 0.9s
Project 'FluentAssertions.Web' has the following package references
   [netstandard2.0]:
   Top-level Package             Requested       Resolved
   > FluentAssertions            [6.5.1,8.0.0)   6.5.1
   > NETStandard.Library   (A)   [2.0.3, )       2.0.3

   Transitive Package                            Resolved
   > Microsoft.AspNet.WebApi.Client              6.0.0
   > Microsoft.Bcl.AsyncInterfaces               8.0.0
   > Microsoft.NETCore.Platforms                 1.1.0
   > Newtonsoft.Json                             13.0.3
   > Newtonsoft.Json.Bson                        1.0.2
   > System.Buffers                              4.5.1
   > System.Memory                               4.5.5
   > System.Net.Http.Json                        8.0.1
   > System.Numerics.Vectors                     4.4.0
   > System.Runtime.CompilerServices.Unsafe      6.0.0
   > System.Text.Encodings.Web                   8.0.0
   > System.Text.Json                            8.0.5
   > System.Threading.Tasks.Extensions           4.5.4

(A) : Auto-referenced package.
```
**After**
```
λ dotnet list src/FluentAssertions.Web/FluentAssertions.Web.csproj package --include-transitive
Restore complete (0.7s)

Build succeeded in 1.2s
Project 'FluentAssertions.Web' has the following package references
   [netstandard2.0]:
   Top-level Package             Requested       Resolved
   > FluentAssertions            [6.5.1,8.0.0)   6.5.1
   > NETStandard.Library   (A)   [2.0.3, )       2.0.3

   Transitive Package                            Resolved
   > Microsoft.AspNetCore.WebUtilities           2.3.0
   > Microsoft.Bcl.AsyncInterfaces               8.0.0
   > Microsoft.Extensions.Primitives             8.0.0
   > Microsoft.Net.Http.Headers                  2.3.0
   > Microsoft.NETCore.Platforms                 1.1.0
   > System.Buffers                              4.6.0
   > System.Memory                               4.5.5
   > System.Net.Http.Json                        8.0.1
   > System.Numerics.Vectors                     4.4.0
   > System.Runtime.CompilerServices.Unsafe      6.0.0
   > System.Text.Encodings.Web                   8.0.0
   > System.Text.Json                            8.0.5
   > System.Threading.Tasks.Extensions           4.5.4
 ```
